### PR TITLE
Feature/customizable about

### DIFF
--- a/src/app/core/models/organization.model.ts
+++ b/src/app/core/models/organization.model.ts
@@ -8,6 +8,7 @@ export interface IOrganization {
 	owner?: any;
 	moderators?: Array<any>;
 	created?: Date;
+	organizationUrl?: string;
 }
 
 export class Organization implements IOrganization {
@@ -19,6 +20,7 @@ export class Organization implements IOrganization {
 		public owner: any = {},
 		public moderators: any = [],
 		public imageUrl: string = '',
-		public iconUrl: string = ''
+		public iconUrl: string = '',
+		public organizationUrl: ''
 	) { }
 }

--- a/src/app/organization/create/organization-create.component.html
+++ b/src/app/organization/create/organization-create.component.html
@@ -41,6 +41,14 @@
 				</mat-error>
 			</mat-form-field>
 
+			<mat-form-field>
+				<input matInput
+					type="url"
+				    placeholder="(optional) URL to your organization"
+				    formControlName="organizationUrl"
+				    >
+			</mat-form-field>
+
 			<mat-form-field class="example-chip-list" *ngIf="auth.isAdmin()">
 				<mat-chip-list #chipList>
 					<mat-chip *ngIf="owner"

--- a/src/app/organization/create/organization-create.component.ts
+++ b/src/app/organization/create/organization-create.component.ts
@@ -33,6 +33,7 @@ export class OrganizationCreateComponent implements OnInit {
 	organizationForm = new FormGroup({
 		name: new FormControl('', [Validators.required]),
 		url: new FormControl('', [Validators.required]),
+		organizationUrl: new FormControl(''),
 		description: new FormControl('', [Validators.required]),
 		imageUrl: new FormControl('', [Validators.required]),
 		iconUrl: new FormControl('', [Validators.required]),

--- a/src/app/organization/edit/organization-edit.component.html
+++ b/src/app/organization/edit/organization-edit.component.html
@@ -40,6 +40,14 @@
 				</mat-error>
 			</mat-form-field>
 
+			<mat-form-field>
+				<input matInput
+					type="url"
+				    placeholder="(optional) URL to your organization"
+				    formControlName="organizationUrl"
+				    >
+			</mat-form-field>
+
 			<mat-form-field class="example-chip-list" *ngIf="auth.isAdmin()">
 				<mat-chip-list #chipList>
 					<mat-chip *ngIf="owner"

--- a/src/app/organization/edit/organization-edit.component.ts
+++ b/src/app/organization/edit/organization-edit.component.ts
@@ -112,7 +112,8 @@ export class OrganizationEditComponent implements OnInit {
 						'name': organization.name,
 						'description': organization.description,
 						'url': organization.url,
-						'moderators': organization.moderators
+						'moderators': organization.moderators,
+						'organizationUrl': organization.organizationUrl
 					});
 
 					this.meta.updateTags(
@@ -208,6 +209,7 @@ export class OrganizationEditComponent implements OnInit {
 		this.organization.owner = this.owner;
 		this.organization.imageUrl = this.backgroundImage.src;
 		this.organization.iconUrl = this.iconImage.src;
+
 		this.organizationService.update({ id: this.organization._id, entity: this.organization })
 			.pipe(finalize(() => { this.isLoading = false; }))
 			.subscribe((t) => {

--- a/src/app/organization/edit/organization-edit.component.ts
+++ b/src/app/organization/edit/organization-edit.component.ts
@@ -34,6 +34,7 @@ export class OrganizationEditComponent implements OnInit {
 	organizationForm = new FormGroup({
 		name: new FormControl('', [Validators.required]),
 		url: new FormControl('', [Validators.required]),
+		organizationUrl: new FormControl(''),
 		description: new FormControl('', [Validators.required]),
 		imageUrl: new FormControl(''),
 		iconUrl: new FormControl(''),

--- a/src/app/shell/shell.component.html
+++ b/src/app/shell/shell.component.html
@@ -47,6 +47,16 @@
 					<mat-divider></mat-divider>
 
 					<a mat-list-item
+						*ngIf="organization && organization.organizationUrl"
+						href="#"
+						(click)="visitOrganizationUrl($event)"
+						target="_blank"
+						>
+						<span translate
+							matLine>About {{ organization.name }}</span>
+					</a>
+					
+					<a mat-list-item
 					    href="https://newvote.org/about-us"
 					    target="_blank">
 						<span translate

--- a/src/app/shell/shell.component.ts
+++ b/src/app/shell/shell.component.ts
@@ -30,7 +30,6 @@ export class ShellComponent implements OnInit {
 	ngOnInit() {
 		this.organizationService.get().subscribe(org => {
 			this.organization = org;
-			console.log(this.organization, 'this is organization');
 		});
 	}
 

--- a/src/app/shell/shell.component.ts
+++ b/src/app/shell/shell.component.ts
@@ -30,6 +30,7 @@ export class ShellComponent implements OnInit {
 	ngOnInit() {
 		this.organizationService.get().subscribe(org => {
 			this.organization = org;
+			console.log(this.organization, 'this is organization');
 		});
 	}
 
@@ -85,5 +86,19 @@ export class ShellComponent implements OnInit {
 
 	get title(): string {
 		return this.meta.getAppBarTitle();
+	}
+
+	visitOrganizationUrl (event: any) {
+		event.preventDefault();
+		let { organizationUrl: url } = this.organization;
+		url = this.setHttp(url);
+		window.open(url, '_blank');
+	}
+
+	setHttp(link: string) {
+		if (link.search(/^http[s]?\:\/\//) === -1) {
+			link = 'http://' + link;
+		}
+		return link;
 	}
 }

--- a/src/app/shell/shell.component.ts
+++ b/src/app/shell/shell.component.ts
@@ -96,7 +96,7 @@ export class ShellComponent implements OnInit {
 
 	setHttp(link: string) {
 		if (link.search(/^http[s]?\:\/\//) === -1) {
-			link = 'http://' + link;
+			link = 'https://' + link;
 		}
 		return link;
 	}


### PR DESCRIPTION
Front end for Trello card - Customisable about (accessible by leaders profile)

Adds new key `organizationUrl` to organization model
On edit and create organization pages owner's can enter their own website.
If there is a organization website entered a new link will appear in the side bar above "Above New Vote". 
Sidebar Link does not update immediately and page needs to be refreshed.