### PR TITLE
Feature/header customize

### DIFF
--- a/src/app/core/models/issue.model.ts
+++ b/src/app/core/models/issue.model.ts
@@ -8,6 +8,7 @@ export interface IIssue {
 	topics?: Array<any>;
 	created?: Date;
 	organizations: any;
+	mediaHeading?: string;
 }
 
 export class Issue implements IIssue {
@@ -16,6 +17,6 @@ export class Issue implements IIssue {
 		public imageUrl: string = '',
 		public description: string = '',
 		public organizations: any = {},
-		public topics: Array<any> = []
+		public topics: Array<any> = [],
 	) { }
 }

--- a/src/app/issue/view/issue-view.component.html
+++ b/src/app/issue/view/issue-view.component.html
@@ -79,7 +79,7 @@
 		fxLayoutAlign="center center"
 		fxFlex.gt-sm="690px"
 		fxFlex.gt-md="800px"
-		*ngIf="!headingEdit"
+		*ngIf="media && !headingEdit"
 		>
 		<h3 class="mat-headline" 
 			*ngIf="media && media.length > 0"
@@ -89,10 +89,10 @@
 		</h3>
 		<button 
 			mat-icon-button
-			matTooltip="Edit this Issue"
+			matTooltip="Edit no Issue"
 			color="accent"
 			(click)="toggleHeader()"
-			*ngIf="auth.isModerator()"
+			*ngIf="(media && media.length > 0 ) && auth.isModerator()"
 			>
 				<mat-icon aria-label="Edit the issue">edit</mat-icon>
 		</button>

--- a/src/app/issue/view/issue-view.component.html
+++ b/src/app/issue/view/issue-view.component.html
@@ -71,7 +71,50 @@
 		</div>
 	</div>
 </mat-toolbar>
-
+<div class="container"
+    fxLayoutAlign="center center	">
+	<div fxFlex.gt-sm="690px"
+		fxFlex.gt-md="800px"
+		*ngIf="!headingEdit"
+		>
+		<span class="mat-headline" *ngIf="media && media.length > 0">
+			{{ this.issue.mediaHeading || "Third Party Media"}}
+		</span>
+		<button 
+			*ngIf="auth.isModerator(issue)"
+			mat-icon-button
+			matTooltip="Edit this Issue"
+			color="accent"
+			(click)="toggleHeader()"
+			>
+				<mat-icon aria-label="Edit the issue">edit</mat-icon>
+			</button>
+	</div>
+	<div 
+		*ngIf="headingEdit && auth.isModerator(issue)"
+		fxFlex.gt-sm="690px"
+	    fxFlex.gt-md="800px"
+		>
+		<mat-form-field class="example-full-width">
+			<input 
+				#newHeading 
+				matInput 
+				placeholder="Heading Name"
+				(keyup.enter)="handleSubmit(newHeading.value)"
+				(blur)="handleSubmit()"
+				>
+			<button 
+				mat-icon-button
+				matSuffix
+				color="accent"
+				(click)="handleSubmit(newHeading.value)"
+				>
+				<mat-icon >send</mat-icon>
+			</button>
+			
+		</mat-form-field>
+	</div>
+</div>
 <app-swiper-wrapper path="/media"
 	[items]="media"
     model="Media"

--- a/src/app/issue/view/issue-view.component.html
+++ b/src/app/issue/view/issue-view.component.html
@@ -72,28 +72,36 @@
 	</div>
 </mat-toolbar>
 <div class="container"
-    fxLayoutAlign="center center	">
-	<div fxFlex.gt-sm="690px"
+	fxLayoutAlign="center center"
+	*ngIf="media"
+	>
+	<div
+		fxLayoutAlign="center center"
+		fxFlex.gt-sm="690px"
 		fxFlex.gt-md="800px"
 		*ngIf="!headingEdit"
 		>
-		<span class="mat-headline" *ngIf="media && media.length > 0">
+		<h3 class="mat-headline" 
+			*ngIf="media && media.length > 0"
+			[ngStyle]="{ 'margin-bottom': '0px'}"
+			>
 			{{ this.issue.mediaHeading || "Third Party Media"}}
-		</span>
+		</h3>
 		<button 
-			*ngIf="auth.isModerator(issue)"
 			mat-icon-button
 			matTooltip="Edit this Issue"
 			color="accent"
 			(click)="toggleHeader()"
+			*ngIf="auth.isModerator()"
 			>
 				<mat-icon aria-label="Edit the issue">edit</mat-icon>
-			</button>
-	</div>
+		</button>
+	</div>		
 	<div 
-		*ngIf="headingEdit && auth.isModerator(issue)"
+		fxLayoutAlign="center center"
 		fxFlex.gt-sm="690px"
-	    fxFlex.gt-md="800px"
+		fxFlex.gt-md="800px"
+		*ngIf="auth.isModerator() && headingEdit"
 		>
 		<mat-form-field class="example-full-width">
 			<input 
@@ -110,8 +118,7 @@
 				(click)="handleSubmit(newHeading.value)"
 				>
 				<mat-icon >send</mat-icon>
-			</button>
-			
+			</button>	
 		</mat-form-field>
 	</div>
 </div>

--- a/src/app/issue/view/issue-view.component.ts
+++ b/src/app/issue/view/issue-view.component.ts
@@ -33,6 +33,7 @@ export class IssueViewComponent implements OnInit {
 	isLoading: boolean;
 	voteSnack: any;
 	headingEdit = false;
+	isMod: boolean;
 
 	constructor(
 		private topicService: TopicService,
@@ -54,6 +55,8 @@ export class IssueViewComponent implements OnInit {
 			const ID = params.get('id');
 			this.getIssue(ID);
 		});
+
+		this.isMod = this.auth.isModerator()
 	}
 
 	getIssue(id: string) {

--- a/src/app/issue/view/issue-view.component.ts
+++ b/src/app/issue/view/issue-view.component.ts
@@ -174,7 +174,6 @@ export class IssueViewComponent implements OnInit {
 	handleSubmit(value?: string) {
 		this.toggleHeader();
 		if (!value) {
-			console.log(this.issue.mediaHeading);
 			return;
 		}
 

--- a/src/app/issue/view/issue-view.component.ts
+++ b/src/app/issue/view/issue-view.component.ts
@@ -32,6 +32,7 @@ export class IssueViewComponent implements OnInit {
 	media: Array<Media>;
 	isLoading: boolean;
 	voteSnack: any;
+	headingEdit = false;
 
 	constructor(
 		private topicService: TopicService,
@@ -164,6 +165,24 @@ export class IssueViewComponent implements OnInit {
 			horizontalPosition: 'right',
 			verticalPosition: 'bottom',
 		});
+	}
+
+	toggleHeader() {
+		this.headingEdit = this.headingEdit ? false : true;
+	}
+
+	handleSubmit(value?: string) {
+		this.toggleHeader();
+		if (!value) {
+			console.log(this.issue.mediaHeading);
+			return;
+		}
+
+		this.issue.mediaHeading = value;
+		this.issueService.update({ id: this.issue._id, entity: this.issue })
+			.subscribe((t) => {
+				this.issue = t;
+			});
 	}
 
 }

--- a/src/app/issue/view/issue-view.component.ts
+++ b/src/app/issue/view/issue-view.component.ts
@@ -33,7 +33,6 @@ export class IssueViewComponent implements OnInit {
 	isLoading: boolean;
 	voteSnack: any;
 	headingEdit = false;
-	isMod: boolean;
 
 	constructor(
 		private topicService: TopicService,
@@ -55,8 +54,6 @@ export class IssueViewComponent implements OnInit {
 			const ID = params.get('id');
 			this.getIssue(ID);
 		});
-
-		this.isMod = this.auth.isModerator()
 	}
 
 	getIssue(id: string) {


### PR DESCRIPTION
Added a editable heading on the issue page, by default is 'Third Party Media'
Updated Issue model to include a heading property.
Added new section for heading above the swipe component that checks whether a user is moderator or not. 

When updating the backend with the heading, the app would not save the results unless I subscribed to the result even after refreshing the page. 