### PR TITLE
Mat-chip max-width

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -8,3 +8,7 @@
 		margin-bottom: 16px !important;
 	}
 }
+
+::ng-deep .mat-chip {
+		max-width: 300px !important;
+}


### PR DESCRIPTION
Updated css at the app level to enforce mat-chip component to have a max-width of 300px.