### PR TITLE
Feature/leader model

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Launch Chrome against localhost",
+            "url": "http://kip.localhost.newvote.org:4200",
+            "webRoot": "${workspaceFolder}"
+        }
+    ]
+}

--- a/src/app/auth/auth-routing.module.ts
+++ b/src/app/auth/auth-routing.module.ts
@@ -10,6 +10,7 @@ import { VerifyComponent } from './verify/verify.component';
 const routes: Routes = [
 	{ path: 'login', component: LoginComponent, data: { title: extract('Login') } },
 	{ path: 'signup', component: SignupComponent, data: { title: extract('Create Account') } },
+	{ path: 'signup/:id', component: SignupComponent, data: { title: extract('Create Account') } },
 	{ path: 'verify', component: VerifyComponent, data: { title: extract('Verify Account') } },
 	{ path: 'forgot', component: ForgotComponent, data: { title: extract('Forgot Password') } },
 	{ path: 'forgot/:token/:email', component: ForgotComponent, data: { title: extract('Reset Password') } },

--- a/src/app/auth/signup/signup.component.ts
+++ b/src/app/auth/signup/signup.component.ts
@@ -6,6 +6,7 @@ import { MetaService } from '@app/core/meta.service';
 
 import { environment } from '@env/environment';
 import { Logger, I18nService, AuthenticationService } from '@app/core';
+import { arrayExpression } from 'babel-types';
 
 const log = new Logger('Signup');
 
@@ -42,7 +43,7 @@ export class SignupComponent implements OnInit {
 		// extract verificationCode if directed via email
 		this.verificationCode = this.route.snapshot.params.id
 			? this.route.snapshot.params.id
-			: false;
+			: '';
 	}
 
 	signup() {

--- a/src/app/auth/signup/signup.component.ts
+++ b/src/app/auth/signup/signup.component.ts
@@ -20,13 +20,14 @@ export class SignupComponent implements OnInit {
 	error: any;
 	signupForm: FormGroup;
 	isLoading = false;
+	verificationCode: string;
 
 	constructor(private router: Router,
 		private route: ActivatedRoute,
 		private formBuilder: FormBuilder,
 		private i18nService: I18nService,
 		private authenticationService: AuthenticationService,
-		private meta: MetaService
+		private meta: MetaService,
 	) {
 		this.createForm();
 	}
@@ -37,11 +38,16 @@ export class SignupComponent implements OnInit {
 				title: `Create account`,
 				description: 'Make your voice heard, create an account today!'
 			});
+
+		// extract verificationCode if directed via email
+		this.verificationCode = this.route.snapshot.params.id
+			? this.route.snapshot.params.id
+			: false;
 	}
 
 	signup() {
 		this.isLoading = true;
-		this.authenticationService.signup(this.signupForm.value)
+		this.authenticationService.signup(this.signupForm.value, this.verificationCode)
 			.pipe(finalize(() => {
 				this.signupForm.markAsPristine();
 				this.isLoading = false;

--- a/src/app/core/authentication/authentication.service.ts
+++ b/src/app/core/authentication/authentication.service.ts
@@ -35,7 +35,7 @@ export interface ResetContext {
 
 const routes = {
 	signin: () => `/auth/signin`,
-	signup: () => `/auth/signup`,
+	signup: (id?: string) => `/auth/signup` + id ? `/${id}` : '',
 	forgot: () => `/auth/forgot`,
 	reset: () => `/auth/reset`,
 	randomGet: () => `/topics`,
@@ -103,10 +103,10 @@ export class AuthenticationService {
 	 * @param context The signup parameters.
 	 * @return The user credentials.
 	 */
-	signup(context: LoginContext): Observable<Credentials> {
+	signup(context: LoginContext, verificationCode?: string): Observable<Credentials> {
 		context.organizations = [this.organizationService.org];
 		return this.httpClient
-			.post<Credentials>(routes.signup(), context)
+			.post<Credentials>(routes.signup(verificationCode), context)
 			.pipe(
 				map((res) => {
 					this.setCredentials(res, context.remember);

--- a/src/app/core/authentication/authentication.service.ts
+++ b/src/app/core/authentication/authentication.service.ts
@@ -35,7 +35,9 @@ export interface ResetContext {
 
 const routes = {
 	signin: () => `/auth/signin`,
-	signup: (id?: string) => `/auth/signup` + id ? `/${id}` : '',
+	signup: (id?: string) => {
+		return `/auth/signup${id ? `/${id}` : ''}`;
+	},
 	forgot: () => `/auth/forgot`,
 	reset: () => `/auth/reset`,
 	randomGet: () => `/topics`,

--- a/src/app/core/http/organization/organization.service.ts
+++ b/src/app/core/http/organization/organization.service.ts
@@ -111,7 +111,6 @@ export class OrganizationService {
 	}
 
 	setFutureOwner(context: OrganizationContext): Observable<any> {
-		console.log(context.entity, 'this is context.entity');
 		return this.httpClient
 			.cache(context.forceUpdate)
 			.put(routes.updateOwner(context), context.entity)

--- a/src/app/core/http/organization/organization.service.ts
+++ b/src/app/core/http/organization/organization.service.ts
@@ -11,6 +11,7 @@ const routes = {
 	view: (c: OrganizationContext) => `/organizations/${c.id}`,
 	create: (c: OrganizationContext) => `/organizations`,
 	update: (c: OrganizationContext) => `/organizations/${c.id}`,
+	updateOwner: (c: OrganizationContext) => `/organizations/owner/${c.id}`,
 	delete: (c: OrganizationContext) => `/organizations/${c.id}`
 };
 
@@ -106,6 +107,17 @@ export class OrganizationService {
 			.pipe(
 				map((res: any) => res),
 				catchError((e) => of({ error: e }))
+			);
+	}
+
+	setFutureOwner(context: OrganizationContext): Observable<any> {
+		console.log(context.entity, 'this is context.entity');
+		return this.httpClient
+			.cache(context.forceUpdate)
+			.put(routes.updateOwner(context), context.entity)
+			.pipe(
+				map((res: any) => res),
+				catchError((e) => of({ error: e}))
 			);
 	}
 

--- a/src/app/core/models/organization.model.ts
+++ b/src/app/core/models/organization.model.ts
@@ -10,6 +10,7 @@ export interface IOrganization {
 	moderators?: Array<any>;
 	created?: Date;
 	organizationUrl?: string;
+	futureOwner?: string;
 }
 
 export class Organization implements IOrganization {
@@ -23,6 +24,7 @@ export class Organization implements IOrganization {
 		public moderators: any = [],
 		public imageUrl: string = '',
 		public iconUrl: string = '',
-		public organizationUrl: ''
+		public organizationUrl: '',
+		public futureOwner: ''
 	) { }
 }

--- a/src/app/core/models/organization.model.ts
+++ b/src/app/core/models/organization.model.ts
@@ -11,7 +11,7 @@ export interface IOrganization {
 	created?: Date;
 	organizationUrl?: string;
 	futureOwner?: string;
-	newLeaderEmail: string;
+	newLeaderEmail?: string;
 }
 
 export class Organization implements IOrganization {
@@ -25,8 +25,8 @@ export class Organization implements IOrganization {
 		public moderators: any = [],
 		public imageUrl: string = '',
 		public iconUrl: string = '',
-		public organizationUrl: '',
-		public futureOwner: '',
-		public newLeaderEmail: ''
+		public organizationUrl: string =  '',
+		public futureOwner: any = {},
+		public newLeaderEmail: string = ''
 	) { }
 }

--- a/src/app/core/models/organization.model.ts
+++ b/src/app/core/models/organization.model.ts
@@ -11,6 +11,7 @@ export interface IOrganization {
 	created?: Date;
 	organizationUrl?: string;
 	futureOwner?: string;
+	newLeaderEmail: string;
 }
 
 export class Organization implements IOrganization {
@@ -25,6 +26,7 @@ export class Organization implements IOrganization {
 		public imageUrl: string = '',
 		public iconUrl: string = '',
 		public organizationUrl: '',
-		public futureOwner: ''
+		public futureOwner: '',
+		public newLeaderEmail: ''
 	) { }
 }

--- a/src/app/organization/create/organization-create.component.html
+++ b/src/app/organization/create/organization-create.component.html
@@ -64,12 +64,17 @@
 					</mat-chip>
 					<input placeholder="Select Community Owner"
 						#userInput
+						type="text"
 						formControlName="owner"
 						[matAutocomplete]="auto"
 						[matChipInputFor]="chipList"
 						[matChipInputSeparatorKeyCodes]="separatorKeysCodes"
-						[matChipInputAddOnBlur]="true">
+						[matChipInputAddOnBlur]="true"
+						[readonly]="owner"
+						(input)="handleChange(userInput.value)"
+						>
 				</mat-chip-list>
+				<mat-hint color="primary">If user does not appear in dropdown. Enter email to invite to community.</mat-hint>
 				<mat-autocomplete #auto="matAutocomplete"
 					(optionSelected)="userSelected($event)">
 					<mat-option *ngFor="let user of filteredUsers | async"
@@ -144,7 +149,7 @@
 
 			<button mat-flat-button
 			    type="submit"
-			    [disabled]="!organizationForm.valid || isLoading"
+			    [disabled]="(!organizationForm.valid  && isValid) || isLoading || (!organizationForm.valid  && !owner)"
 			    color="primary">Create</button>
 		</form>
 	</mat-card>

--- a/src/app/organization/create/organization-create.component.html
+++ b/src/app/organization/create/organization-create.component.html
@@ -149,7 +149,7 @@
 
 			<button mat-flat-button
 			    type="submit"
-			    [disabled]="(!organizationForm.valid  && isValid) || isLoading || (!organizationForm.valid  && !owner)"
+			    [disabled]="!organizationForm.valid || isLoading "
 			    color="primary">Create</button>
 		</form>
 	</mat-card>

--- a/src/app/organization/create/organization-create.component.ts
+++ b/src/app/organization/create/organization-create.component.ts
@@ -30,6 +30,8 @@ export class OrganizationCreateComponent implements OnInit {
 	backgroundImage: any;
 	iconImage: any;
 	uploader: FileUploader;
+	isValid = false;
+
 	organizationForm = new FormGroup({
 		name: new FormControl('', [Validators.required]),
 		url: new FormControl('', [Validators.required]),
@@ -127,10 +129,19 @@ export class OrganizationCreateComponent implements OnInit {
 		}
 	}
 
+
 	onSave() {
 		this.isLoading = true;
-		this.organization = <Organization>this.organizationForm.value;
-		this.organization.owner = this.owner;
+		this.organization = this.organizationForm.value;
+
+		if (!this.owner && this.isValid) {
+			this.organization.owner = null;
+			this.organization.newLeaderEmail = this.userInput.nativeElement.value;
+			this.userInput.nativeElement.value = '';
+		} else {
+			this.organization.owner = this.owner;
+			this.organization.newLeaderEmail = null;
+		}
 
 		this.uploader.onCompleteAll = () => {
 			// console.log('completed all');
@@ -203,6 +214,11 @@ export class OrganizationCreateComponent implements OnInit {
 		const index = moderators.indexOf(mod);
 		moderators.splice(index, 1);
 		this.organizationForm.patchValue(moderators);
+	}
+
+	handleChange(email: any) {
+		// https://tylermcginnis.com/validate-email-address-javascript/
+		this.isValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 	}
 
 	private _filter(value: any): User[] {

--- a/src/app/organization/edit/organization-edit.component.html
+++ b/src/app/organization/edit/organization-edit.component.html
@@ -3,7 +3,7 @@
 <div class="container"
     fxLayoutAlign="center center">
 	<mat-card fxFlex.gt-sm="60"
-	    fxFlex="100">
+	   >
 		<form [formGroup]="organizationForm"
 		    fxLayout="column"
 		    (ngSubmit)="onSave()"
@@ -51,37 +51,51 @@
 				    formControlName="organizationUrl"
 				    >
 			</mat-form-field>
-<!-- 
-			<mat-form-field class="example-chip-list" *ngIf="auth.isAdmin()">
-				<mat-chip-list #chipList>
-					<mat-chip *ngIf="owner"
-					    [selectable]="false"
-					    [removable]="true"
-					    (removed)="ownerRemoved(owner)">
-						{{owner.firstName}} {{owner.lastName}} {{owner.email}}
-						<mat-icon matChipRemove>cancel</mat-icon>
-					</mat-chip>
-					<input placeholder="Select Community Owner"
-					    #ownerInput
-					    formControlName="owner"
-					    [matAutocomplete]="ownerAuto"
-					    [matChipInputFor]="chipList"
-					    [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
-					    [matChipInputAddOnBlur]="true">
-				</mat-chip-list>
-				<mat-autocomplete #ownerAuto="matAutocomplete"
-				    (optionSelected)="ownerSelected($event)">
-					<mat-option *ngFor="let user of filteredOwners | async"
-					    [value]="user">
-						{{user.firstName}} {{user.lastName}} {{user.email}}
-					</mat-option>
-				</mat-autocomplete>
-			</mat-form-field> -->
-
-			<mat-form-field class="example-chip-list" *ngIf="auth.isAdmin()">
-				<input matInput formControlName="ownerEmail" placeholder="Select or Enter Community Owner Email" value="">
-			</mat-form-field>
-
+			<div fxFlex.gt-sm="60" fxLayout="row">
+				<mat-form-field style="width: 100%; padding-right: 0.5rem" class="example-chip-list" *ngIf="auth.isAdmin()">
+					<mat-chip-list #chipList>
+						<mat-chip *ngIf="owner"
+							[selectable]="false"
+							[removable]="true"
+							(removed)="ownerRemoved(owner)">
+							{{owner.firstName}} {{owner.lastName}} {{owner.email}}
+							<mat-icon matChipRemove>cancel</mat-icon>
+						</mat-chip>
+						<input placeholder="Select Community Owner"
+							#ownerInput
+							formControlName="owner"
+							[matAutocomplete]="ownerAuto"
+							[matChipInputFor]="chipList"
+							[matChipInputSeparatorKeyCodes]="separatorKeysCodes"
+							[matChipInputAddOnBlur]="true"
+							[readonly]="owner"
+							(input)="handleChange(ownerInput.value)"
+							>
+							
+					</mat-chip-list>
+					<mat-hint color="primary">If user does not appear in dropdown. Enter email to invite to community.</mat-hint>
+					<mat-autocomplete #ownerAuto="matAutocomplete"
+						(optionSelected)="ownerSelected($event)">
+						<mat-option *ngFor="let user of filteredOwners | async"
+							[value]="user">
+							{{user.firstName}} {{user.lastName}} {{user.email}}
+						</mat-option>
+					</mat-autocomplete>
+				</mat-form-field>
+				<div
+					*ngIf="!owner && ownerInput"
+					fxLayoutAlign="center center">
+					<button mat-stroked-button 
+						color="primary"
+						type="button"
+						aria-label="Clear"
+						(click)="submitOwnerEmail(ownerInput)"
+						[disabled]="!isValid"
+						>
+						Invite User
+					</button>
+				</div>
+			</div>
 			<mat-form-field class="example-chip-list" *ngIf="auth.isOwner()">
 				<mat-chip-list #modChipList>
 					<mat-chip *ngFor="let mod of organizationForm.value.moderators"

--- a/src/app/organization/edit/organization-edit.component.html
+++ b/src/app/organization/edit/organization-edit.component.html
@@ -51,7 +51,7 @@
 				    formControlName="organizationUrl"
 				    >
 			</mat-form-field>
-
+<!-- 
 			<mat-form-field class="example-chip-list" *ngIf="auth.isAdmin()">
 				<mat-chip-list #chipList>
 					<mat-chip *ngIf="owner"
@@ -76,6 +76,10 @@
 						{{user.firstName}} {{user.lastName}} {{user.email}}
 					</mat-option>
 				</mat-autocomplete>
+			</mat-form-field> -->
+
+			<mat-form-field class="example-chip-list" *ngIf="auth.isAdmin()">
+				<input matInput formControlName="ownerEmail" placeholder="Select or Enter Community Owner Email" value="">
 			</mat-form-field>
 
 			<mat-form-field class="example-chip-list" *ngIf="auth.isOwner()">

--- a/src/app/organization/edit/organization-edit.component.html
+++ b/src/app/organization/edit/organization-edit.component.html
@@ -61,6 +61,14 @@
 							{{owner.firstName}} {{owner.lastName}} {{owner.email}}
 							<mat-icon matChipRemove>cancel</mat-icon>
 						</mat-chip>
+						<mat-chip *ngIf="futureOwner"
+							class="future-chip"
+							[selectable]="false"
+							[removable]="true"
+							(removed)="futureOwnerRemoved(owner)">
+								{{futureOwner.email}} : Pending
+							<mat-icon matChipRemove>cancel</mat-icon>
+						</mat-chip>
 						<input placeholder="Select Community Owner"
 							#ownerInput
 							formControlName="owner"
@@ -68,7 +76,7 @@
 							[matChipInputFor]="chipList"
 							[matChipInputSeparatorKeyCodes]="separatorKeysCodes"
 							[matChipInputAddOnBlur]="true"
-							[readonly]="owner"
+							[readonly]="owner || futureOwner"
 							(input)="handleChange(ownerInput.value)"
 							>
 							
@@ -83,7 +91,7 @@
 					</mat-autocomplete>
 				</mat-form-field>
 				<div
-					*ngIf="!owner && ownerInput"
+					*ngIf="!owner && !futureOwner && ownerInput"
 					fxLayoutAlign="center center">
 					<button mat-stroked-button 
 						color="primary"

--- a/src/app/organization/edit/organization-edit.component.scss
+++ b/src/app/organization/edit/organization-edit.component.scss
@@ -29,3 +29,9 @@
 		height: 250px !important;
 	}
 }
+
+.future-chip {
+	font-size: 0.8em;
+	background-color: #0277bd;
+	color: white;
+}

--- a/src/app/organization/edit/organization-edit.component.ts
+++ b/src/app/organization/edit/organization-edit.component.ts
@@ -36,10 +36,11 @@ export class OrganizationEditComponent implements OnInit {
 		url: new FormControl('', [Validators.required]),
 		organizationUrl: new FormControl(''),
 		description: new FormControl('', [Validators.required]),
-		longDescription: new FormControl('', [Validators.required]),
+		longDescription: new FormControl(''),
 		imageUrl: new FormControl(''),
 		iconUrl: new FormControl(''),
 		owner: new FormControl(''),
+		ownerEmail: new FormControl(''),
 		moderators: new FormControl([]),
 		moderatorsControl: new FormControl([], [Validators.email])
 	});

--- a/src/app/organization/edit/organization-edit.component.ts
+++ b/src/app/organization/edit/organization-edit.component.ts
@@ -297,7 +297,7 @@ export class OrganizationEditComponent implements OnInit {
 					this.openSnackBar(`Something went wrong: ${t.error.status} - ${t.error.statusText}`, 'OK');
 				} else {
 					this.openSnackBar('Succesfully updated', 'OK');
-					this.location.back();
+					// this.location.back();
 				}
 			});
 	}

--- a/src/app/organization/edit/organization-edit.component.ts
+++ b/src/app/organization/edit/organization-edit.component.ts
@@ -279,7 +279,7 @@ export class OrganizationEditComponent implements OnInit {
 
 		// update this.org with form data and the owner manually
 		merge(this.organization, <Organization>this.organizationForm.value);
-		this.organization.owner = this.owner;
+		this.organization.owner = null;
 		this.organization.futureOwner = email;
 
 		this.organizationService.setFutureOwner({ id: this.organization._id, entity: this.organization })

--- a/src/app/organization/edit/organization-edit.component.ts
+++ b/src/app/organization/edit/organization-edit.component.ts
@@ -26,6 +26,7 @@ export class OrganizationEditComponent implements OnInit {
 	organization: Organization;
 	allUsers: Array<User> = [];
 	owner: User;
+	futureOwner: any;
 	filteredOwners: Observable<User[]>;
 	separatorKeysCodes: number[] = [ENTER, COMMA, SPACE];
 	isLoading: boolean;
@@ -43,7 +44,7 @@ export class OrganizationEditComponent implements OnInit {
 		owner: new FormControl(''),
 		futureOwner: new FormControl(''),
 		moderators: new FormControl([]),
-		moderatorsControl: new FormControl([], [Validators.email])
+		moderatorsControl: new FormControl([], [Validators.email]),
 	});
 
 	backgroundImage = {
@@ -108,6 +109,7 @@ export class OrganizationEditComponent implements OnInit {
 					this.backgroundImage.src = organization.imageUrl;
 					this.iconImage.src = organization.iconUrl;
 					this.owner = organization.owner;
+					this.futureOwner = organization.futureOwner;
 
 					organization.moderators = organization.moderators.map((m: any) => m.email ? m.email : m);
 
@@ -118,7 +120,8 @@ export class OrganizationEditComponent implements OnInit {
 						'url': organization.url,
 						'moderators': organization.moderators,
 						'organizationUrl': organization.organizationUrl,
-						'futureOwner': organization.futureOwner
+						'futureOwner': organization.futureOwner,
+						'newLeaderEmail': ''
 					});
 
 					this.meta.updateTags(
@@ -212,6 +215,7 @@ export class OrganizationEditComponent implements OnInit {
 		// update this.org with form data and the owner manually
 		merge(this.organization, <Organization>this.organizationForm.value);
 		this.organization.owner = this.owner;
+		this.organization.futureOwner = this.futureOwner;
 		this.organization.imageUrl = this.backgroundImage.src;
 		this.organization.iconUrl = this.iconImage.src;
 
@@ -266,6 +270,10 @@ export class OrganizationEditComponent implements OnInit {
 		this.owner = null;
 	}
 
+	futureOwnerRemoved() {
+		this.futureOwner = null;
+	}
+
 
 	handleChange(email: any) {
 		// https://tylermcginnis.com/validate-email-address-javascript/
@@ -277,10 +285,10 @@ export class OrganizationEditComponent implements OnInit {
 		this.ownerInput.nativeElement.value = '';
 		this.isValid = false;
 
-		// update this.org with form data and the owner manually
-		merge(this.organization, <Organization>this.organizationForm.value);
 		this.organization.owner = null;
-		this.organization.futureOwner = email;
+		this.organization.futureOwner = null;
+
+		this.organization.newLeaderEmail = email;
 
 		this.organizationService.setFutureOwner({ id: this.organization._id, entity: this.organization })
 			.pipe(finalize(() => { this.isLoading = false; }))


### PR DESCRIPTION
Rewrote organization create and edit components to handle future owners.
Added `newLeaderEmail` property to the organization model.
Created new route for creating future leaders.

Creating an `organization` handles futureleader slightly differently. Instead of having an input that users can press to just send the future leader api call it will send the organization object off to the server and it will be handled there at the same time as creating an organization.

Also the submit button for creating an organization can be used without selecting owner - did not know whether this was intentional or not. Please advise.