### PR TITLE
Suggestions streamline

### DIFF
--- a/src/app/suggestion/create/suggestion-create.component.html
+++ b/src/app/suggestion/create/suggestion-create.component.html
@@ -80,16 +80,6 @@
 				<div class="quill-editor-container cf">
 					<quill-editor formControlName="description"></quill-editor>
 				</div>
-
-				<ng-container *ngIf="createOrEdit === 'create'">
-					<span class='group-label'>Seed the conversation</span>
-					<span class="mat-caption group-label">
-						Hint: To make sure the participants are engaged with the integrated Pol.Is platform as soon as they visit it, you need to “seed” the conversation with a few statements in advance. Try to provide 10 diverse statements about your contribution, seperated with commas. Examples of statements to add could be ones you know to be controversial, or opinions you know in advance you’d like feedback about. Make sure they’re simple and restricted to a single point, so they’re easy for the initial participants to engage with. The visualisation will appear once seven participants vote
-					</span>
-					<div class="quill-editor-container cf">
-						<quill-editor formControlName="statements"></quill-editor>
-					</div>
-				</ng-container>
 				<span class='group-label'>Links to sources</span>
 				<span class="mat-caption group-label">
 					Hint: At least five third-party media sources (articles, videos, podcast or memes) that relate to your contribution.

--- a/src/app/suggestion/edit/suggestion-edit.component.html
+++ b/src/app/suggestion/edit/suggestion-edit.component.html
@@ -28,13 +28,13 @@
 					<quill-editor formControlName="description"></quill-editor>
 				</div>
 
-				<ng-container>
+				<!-- <ng-container>
 					<span class='group-label'>Starting Statements</span>
 					<span class="mat-caption group-label">Hint: Try to provide 10 statements about your suggestion. These should feature diverse perspectives about the Issue. These statements are going to be used to seed the conversations in the integrated Pol.is platform.</span>
 					<div class="quill-editor-container cf">
 						<quill-editor formControlName="statements"></quill-editor>
 					</div>
-				</ng-container>
+				</ng-container> -->
 
 				<span class='group-label'>Related Media</span>
 				<span class="mat-caption group-label">Hint: At least five third-party media sources (articles, videos, podcast or memes) that relate to the Issue.</span>

--- a/src/app/suggestion/view/suggestion-view.component.html
+++ b/src/app/suggestion/view/suggestion-view.component.html
@@ -108,7 +108,7 @@
     fxLayoutAlign="center start">
 	<div fxFlex.gt-sm="690px"
 	    fxFlex.gt-md="800px">
-		<mat-card class='info-card' *ngIf="suggestion.statements">
+		<!-- <mat-card class='info-card' *ngIf="suggestion.statements">
 			<mat-card-header>
 				<mat-card-title>Starting Statements</mat-card-title>
 			</mat-card-header>
@@ -116,7 +116,7 @@
 				<p [innerHtml]="suggestion.statements">
 				</p>
 			</mat-card-content>
-		</mat-card>
+		</mat-card> -->
 
 		<mat-card class='info-card'  *ngIf="suggestion.media.length > 0">
 			<mat-card-header>


### PR DESCRIPTION
I removed the seed the conversation section from the create suggestion page. However with the edit page and the suggestions view I only commented those sections out. 

Did we want all of it removed everywhere? I wasn't entirely sure at the time.