### PR TITLE
Grid list update for home page

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -45,6 +45,7 @@
 		<app-grid-list *ngIf="issues"
 		    path="/issues"
 			model="Issue"
+			[titleCard]=true
 			[itemLimit]="ISSUE_LIMIT"
 			[items]=issues
 			(delete)="onDelete($event)"

--- a/src/app/shared/grid-list/grid-list.component.html
+++ b/src/app/shared/grid-list/grid-list.component.html
@@ -45,13 +45,26 @@
   						</button>
 					</div>
 				</div>
-				<mat-card-content>
-					<mat-card-title translate>
-						<div class="truncate-container">
-							<span class="truncate">{{item.name}}</span>
+				<ng-container *ngIf="!titleCard; then noTitle; else isTitle">
+				</ng-container>
+				<ng-template #noTitle>
+					<mat-card-content>
+						<mat-card-title translate>
+							<div class="truncate-container">
+								<span class="truncate">{{item.name}}</span>
+							</div>
+						</mat-card-title>
+					</mat-card-content>
+				</ng-template>
+				<ng-template #isTitle>
+					<mat-card-content>
+						<mat-card-title class="title-card-header">
+							{{item.name}}
+						</mat-card-title>
+						<div class="title-card-subheader" [innerHtml]="item.description">
 						</div>
-					</mat-card-title>
-				</mat-card-content>
+					</mat-card-content>
+				</ng-template>
 			</mat-card>
 		</div>
 	</div>

--- a/src/app/shared/grid-list/grid-list.component.scss
+++ b/src/app/shared/grid-list/grid-list.component.scss
@@ -45,3 +45,51 @@
 .soft-deleted {
 	border: 2px solid red;
 }
+
+.title-card-header {
+	font-size: 1.2em;
+	font-weight: 600;
+	height: 46px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	margin-bottom: 0;
+}
+
+.title-card-subheader {
+	max-height: 48px;
+	height: 20px;
+	overflow: hidden;
+	min-width: 0;
+	max-width: 350px;
+	margin: 0 !important;
+	p {
+		margin: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+}
+
+@media only screen and (max-width: 600px) {
+	.title-card-subheader {
+		max-width: 400px;
+	}
+}
+
+@media only screen and (max-width: 500px) {
+	.title-card-subheader {
+		max-width: 310px;
+	}
+}
+
+@media only screen and (max-width: 400px) {
+	.title-card-subheader {
+		max-width: 272px;
+	}
+}
+
+@media only screen and (max-width: 360px) {
+	.title-card-subheader {
+		max-width: 240px;
+	}
+}

--- a/src/app/shared/grid-list/grid-list.component.ts
+++ b/src/app/shared/grid-list/grid-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import { Component, OnInit, Input, Output, EventEmitter, ViewEncapsulation } from '@angular/core';
 import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
 import { ConfirmDialogComponent } from '@app/shared/confirm-dialog/confirm-dialog.component';
 
@@ -7,7 +7,8 @@ import { AuthenticationService } from '@app/core/authentication/authentication.s
 @Component({
 	selector: 'app-grid-list',
 	templateUrl: './grid-list.component.html',
-	styleUrls: ['./grid-list.component.scss']
+	styleUrls: ['./grid-list.component.scss'],
+	encapsulation: ViewEncapsulation.None
 })
 export class GridListComponent implements OnInit {
 
@@ -15,6 +16,7 @@ export class GridListComponent implements OnInit {
 	@Input() model: string;
 	@Input() items: Array<any>;
 	@Input() itemLimit: Number;
+	@Input() titleCard: boolean;
 	@Output() delete = new EventEmitter();
 	@Output() softDelete = new EventEmitter();
 	@Output() restore = new EventEmitter();


### PR DESCRIPTION
Used ng-template to create a new version of the card if `grid-list` component is passed a boolean property named `title`.

Had issues with the elipsis showing and used `@media only screen` to limit the text width at certain mobile sizes. Otherwise the card would overflow screen width.