### PR TITLE
Graceful Error Handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -345,7 +345,7 @@
         },
         "load-json-file": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
@@ -372,7 +372,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -404,7 +404,7 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
@@ -927,7 +927,7 @@
         },
         "load-json-file": {
           "version": "2.0.0",
-          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
@@ -974,7 +974,7 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
@@ -1161,7 +1161,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -1275,7 +1275,7 @@
     },
     "@types/q": {
       "version": "0.0.32",
-      "resolved": "http://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
       "integrity": "sha1-vShOV8hPEyXacCur/IKlMoGQwMU=",
       "dev": true
     },
@@ -1833,7 +1833,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -1862,7 +1862,7 @@
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
@@ -1942,7 +1942,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -2209,7 +2209,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -2341,7 +2341,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -2378,7 +2378,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -2432,7 +2432,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -2517,7 +2517,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -2543,7 +2543,7 @@
     },
     "cacache": {
       "version": "10.0.4",
-      "resolved": "http://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
       "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
       "dev": true,
       "requires": {
@@ -8860,7 +8860,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -8873,7 +8873,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -9479,7 +9479,7 @@
           "dependencies": {
             "pify": {
               "version": "2.3.0",
-              "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
               "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
               "dev": true
             }
@@ -9566,7 +9566,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
@@ -9592,7 +9592,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -11321,7 +11321,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -11474,7 +11474,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
           "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
           "dev": true
         }
@@ -11907,7 +11907,7 @@
     },
     "http-proxy-middleware": {
       "version": "0.18.0",
-      "resolved": "http://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.18.0.tgz",
       "integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
       "dev": true,
       "requires": {
@@ -12470,7 +12470,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -12794,7 +12794,7 @@
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
           "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
           "dev": true
         },
@@ -13004,7 +13004,7 @@
       "dependencies": {
         "colors": {
           "version": "1.1.2",
-          "resolved": "http://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
           "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
           "dev": true
         }
@@ -13121,7 +13121,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "optional": true,
@@ -13187,7 +13187,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
@@ -13451,7 +13451,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -13464,7 +13464,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -13712,7 +13712,7 @@
     },
     "material-design-icons-iconfont": {
       "version": "3.0.3",
-      "resolved": "http://registry.npmjs.org/material-design-icons-iconfont/-/material-design-icons-iconfont-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/material-design-icons-iconfont/-/material-design-icons-iconfont-3.0.3.tgz",
       "integrity": "sha1-FUoQhAR9Ticjf6f1o34Qdc7qbfI="
     },
     "math-random": {
@@ -13795,7 +13795,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true,
           "optional": true
@@ -13987,7 +13987,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -14060,7 +14060,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -14294,7 +14294,7 @@
       "dependencies": {
         "semver": {
           "version": "5.3.0",
-          "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true,
           "optional": true
@@ -14391,7 +14391,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "optional": true,
@@ -14405,7 +14405,7 @@
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
           "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
           "dev": true,
           "optional": true
@@ -14708,7 +14708,7 @@
     },
     "octicons": {
       "version": "4.4.0",
-      "resolved": "http://registry.npmjs.org/octicons/-/octicons-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/octicons/-/octicons-4.4.0.tgz",
       "integrity": "sha1-rKO9MvXcHZB6jQ3nRPeODFThlEY=",
       "dev": true
     },
@@ -14754,7 +14754,7 @@
     },
     "opn": {
       "version": "5.3.0",
-      "resolved": "http://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
       "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
       "dev": true,
       "requires": {
@@ -14816,7 +14816,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "optional": true,
@@ -14826,7 +14826,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -14916,7 +14916,7 @@
     },
     "parchment": {
       "version": "1.1.4",
-      "resolved": "http://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
       "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg=="
     },
     "parse-asn1": {
@@ -15075,7 +15075,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
@@ -15264,7 +15264,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -15535,7 +15535,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -15577,13 +15577,13 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
@@ -15789,7 +15789,7 @@
         },
         "yargs": {
           "version": "3.10.0",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "requires": {
@@ -15979,7 +15979,7 @@
     },
     "quill": {
       "version": "1.3.6",
-      "resolved": "http://registry.npmjs.org/quill/-/quill-1.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.6.tgz",
       "integrity": "sha512-K0mvhimWZN6s+9OQ249CH2IEPZ9JmkFuCQeHAOQax3EZ2nDJ3wfGh59mnlQaZV2i7u8eFarx6wAtvQKgShojug==",
       "requires": {
         "clone": "^2.1.1",
@@ -16081,7 +16081,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -16111,7 +16111,7 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -16150,7 +16150,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -16550,7 +16550,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -16601,7 +16601,7 @@
     },
     "sax": {
       "version": "1.1.4",
-      "resolved": "http://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.4.tgz",
       "integrity": "sha1-dLbTPJrh4AFRDxeakRaFiPGu2qk="
     },
     "schema-utils": {
@@ -16848,7 +16848,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -17614,7 +17614,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -17641,7 +17641,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -18203,7 +18203,7 @@
         },
         "sax": {
           "version": "0.5.8",
-          "resolved": "http://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
           "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=",
           "dev": true
         },
@@ -18558,7 +18558,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -18768,7 +18768,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -19824,7 +19824,7 @@
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         }
@@ -19847,7 +19847,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "ngx-quill": "^6.2.0",
     "ngx-swiper-wrapper": "^7.2.1",
     "quill": "^1.3.6",
-    "rxjs": "^6.3.1",
+    "rxjs": "^6.5.2",
     "rxjs-compat": "^6.1.0",
     "zone.js": "^0.8.26"
   },

--- a/src/app/core/http/errors.ts
+++ b/src/app/core/http/errors.ts
@@ -1,0 +1,8 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { throwError } from 'rxjs';
+
+export const handleError = (error: HttpErrorResponse) => {
+	// (e) => of([{ error: e }])
+	console.log('throwiing Error');
+	return throwError(error);
+};

--- a/src/app/core/http/issue/issue.service.ts
+++ b/src/app/core/http/issue/issue.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
-import { Observable, of } from 'rxjs';
+import { HttpClient, HttpParams, HttpErrorResponse } from '@angular/common/http';
+import { Observable, of, throwError } from 'rxjs';
 import { map, catchError } from 'rxjs/operators';
 
 import { IIssue } from '@app/core/models/issue.model';
+import { handleError } from '@app/core/http/errors';
 
 const routes = {
 	list: (c: IssueContext) => `/issues`,
@@ -47,7 +48,7 @@ export class IssueService {
 			.get(routes.list(context), options)
 			.pipe(
 				map((res: Array<any>) => res),
-				catchError((e) => of([{ error: e }]))
+				catchError(handleError)
 			);
 	}
 
@@ -57,8 +58,7 @@ export class IssueService {
 			.get(routes.view(context))
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
-			);
+				catchError(handleError)			);
 	}
 
 	create(context: IssueContext): Observable<any> {
@@ -66,8 +66,7 @@ export class IssueService {
 			.post(routes.create(context), context.entity)
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
-			);
+				catchError(handleError)			);
 	}
 
 	update(context: IssueContext): Observable<any> {
@@ -75,8 +74,7 @@ export class IssueService {
 			.put(routes.update(context), context.entity)
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
-			);
+				catchError(handleError)			);
 	}
 
 	delete(context: IssueContext): Observable<any> {
@@ -84,7 +82,7 @@ export class IssueService {
 			.delete(routes.delete(context))
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
+				catchError(handleError)
 			);
 	}
 

--- a/src/app/core/http/organization/organization.service.ts
+++ b/src/app/core/http/organization/organization.service.ts
@@ -5,6 +5,7 @@ import { Observable, Subscriber, of, BehaviorSubject } from 'rxjs';
 import { map, finalize, catchError } from 'rxjs/operators';
 
 import { Organization } from '@app/core/models/organization.model';
+import { handleError } from '@app/core/http/errors';
 
 const routes = {
 	list: (c: OrganizationContext) => `/organizations`,
@@ -47,7 +48,7 @@ export class OrganizationService {
 				.get('/organizations', { params })
 				.pipe(
 					map((res: Array<Organization>) => res[0]),
-					catchError((e) => of({ error: e }))
+					catchError(handleError)
 				).subscribe((org: Organization) => {
 					this._org = org;
 					this.$org.next(org);
@@ -76,7 +77,7 @@ export class OrganizationService {
 			.get(routes.list(context), { params })
 			.pipe(
 				map((res: Array<any>) => res),
-				catchError((e) => of([{ error: e }]))
+				catchError(handleError)
 			);
 	}
 
@@ -86,7 +87,7 @@ export class OrganizationService {
 			.get(routes.view(context))
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
+				catchError(handleError)
 			);
 	}
 
@@ -96,7 +97,7 @@ export class OrganizationService {
 			.post(routes.create(context), context.entity)
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
+				catchError(handleError)
 			);
 	}
 
@@ -106,7 +107,7 @@ export class OrganizationService {
 			.put(routes.update(context), context.entity)
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
+				catchError(handleError)
 			);
 	}
 
@@ -116,7 +117,7 @@ export class OrganizationService {
 			.put(routes.updateOwner(context), context.entity)
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e}))
+				catchError(handleError)
 			);
 	}
 
@@ -126,7 +127,7 @@ export class OrganizationService {
 			.delete(routes.delete(context))
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
+				catchError(handleError)
 			);
 	}
 

--- a/src/app/core/http/proposal/proposal.service.ts
+++ b/src/app/core/http/proposal/proposal.service.ts
@@ -4,6 +4,7 @@ import { Observable, of } from 'rxjs';
 import { map, catchError } from 'rxjs/operators';
 
 import { IProposal } from '@app/core/models/proposal.model';
+import { handleError } from '@app/core/http/errors';
 
 const routes = {
 	list: (c: ProposalContext) => `/proposals`,
@@ -43,7 +44,7 @@ export class ProposalService {
 			.get(routes.list(context), { params })
 			.pipe(
 				map((res: Array<any>) => res),
-				catchError((e) => of([{ error: e }]))
+				catchError(handleError)
 			);
 	}
 
@@ -53,7 +54,7 @@ export class ProposalService {
 			.get(routes.view(context))
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
+				catchError(handleError)
 			);
 	}
 
@@ -63,7 +64,7 @@ export class ProposalService {
 			.post(routes.create(context), context.entity)
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
+				catchError(handleError)
 			);
 	}
 
@@ -73,7 +74,7 @@ export class ProposalService {
 			.put(routes.update(context), context.entity)
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
+				catchError(handleError)
 			);
 	}
 
@@ -83,7 +84,7 @@ export class ProposalService {
 			.delete(routes.delete(context))
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
+				catchError(handleError)
 			);
 	}
 

--- a/src/app/core/http/solution/solution.service.ts
+++ b/src/app/core/http/solution/solution.service.ts
@@ -4,6 +4,7 @@ import { Observable, of } from 'rxjs';
 import { map, catchError } from 'rxjs/operators';
 
 import { ISolution } from '@app/core/models/solution.model';
+import { handleError } from '@app/core/http/errors';
 
 const routes = {
 	list: (c: SolutionContext) => `/solutions`,
@@ -43,7 +44,7 @@ export class SolutionService {
 			.get(routes.list(context), { params })
 			.pipe(
 				map((res: Array<any>) => res),
-				catchError((e) => of([{ error: e }]))
+				catchError(handleError)
 			);
 	}
 
@@ -60,7 +61,7 @@ export class SolutionService {
 			.get(routes.view(context), { params })
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
+				catchError(handleError)
 			);
 	}
 
@@ -70,7 +71,7 @@ export class SolutionService {
 			.post(routes.create(context), context.entity)
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
+				catchError(handleError)
 			);
 	}
 
@@ -80,7 +81,7 @@ export class SolutionService {
 			.put(routes.update(context), context.entity)
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
+				catchError(handleError)
 			);
 	}
 
@@ -90,7 +91,7 @@ export class SolutionService {
 			.delete(routes.delete(context))
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
+				catchError(handleError)
 			);
 	}
 

--- a/src/app/core/http/state/state.service.spec.ts
+++ b/src/app/core/http/state/state.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { StateService } from './state.service';
+
+describe('StateService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: StateService = TestBed.get(StateService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/core/http/state/state.service.ts
+++ b/src/app/core/http/state/state.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+enum AppState {
+	loading = 'loading',
+	loaded = 'loaded',
+	serverError = 'serverError',
+	error = 'error',
+	complete = 'complete'
+}
+
+@Injectable({
+	providedIn: 'root'
+})
+export class StateService {
+
+	_loadingState = new BehaviorSubject<AppState>(AppState.loading);
+	loadingState$ = this._loadingState.asObservable();
+
+	constructor() { }
+
+	get loadingState() {
+		return this._loadingState.getValue();
+	}
+
+	set loadingState(state: string) {
+		this._loadingState.next(AppState[`${state}`]);
+	}
+
+	setLoadingState(state: string) {
+		this.loadingState = state;
+	}
+}

--- a/src/app/core/http/suggestion/suggestion.service.ts
+++ b/src/app/core/http/suggestion/suggestion.service.ts
@@ -4,6 +4,7 @@ import { Observable, of } from 'rxjs';
 import { map, catchError } from 'rxjs/operators';
 
 import { ISuggestion, Suggestion } from '@app/core/models/suggestion.model';
+import { handleError } from '@app/core/http/errors';
 
 const routes = {
 	list: (c: SuggestionContext) => `/suggestions`,
@@ -41,7 +42,7 @@ export class SuggestionService {
 			.get(routes.list(context), { params })
 			.pipe(
 				map((res: Array<any>) => res),
-				catchError((e) => of([{ error: e }]))
+				catchError(handleError)
 			);
 	}
 
@@ -51,7 +52,7 @@ export class SuggestionService {
 			.get(routes.view(context))
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
+				catchError(handleError)
 			);
 	}
 
@@ -61,7 +62,7 @@ export class SuggestionService {
 			.post(routes.create(context), context.entity)
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
+				catchError(handleError)
 			);
 	}
 
@@ -71,7 +72,7 @@ export class SuggestionService {
 			.put(routes.update(context), context.entity)
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
+				catchError(handleError)
 			);
 	}
 
@@ -81,7 +82,7 @@ export class SuggestionService {
 			.delete(routes.delete(context))
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
+				catchError(handleError)
 			);
 	}
 

--- a/src/app/core/http/topic/topic.service.ts
+++ b/src/app/core/http/topic/topic.service.ts
@@ -4,6 +4,7 @@ import { Observable, of } from 'rxjs';
 import { map, catchError } from 'rxjs/operators';
 
 import { ITopic } from '@app/core/models/topic.model';
+import { handleError } from '@app/core/http/errors';
 
 const routes = {
 	list: (c: TopicContext) => `/topics`,
@@ -43,7 +44,7 @@ export class TopicService {
 			.get(routes.list(context), { params })
 			.pipe(
 				map((res: Array<any>) => res),
-				catchError((e) => of([{ error: e }]))
+				catchError(handleError)
 			);
 	}
 
@@ -53,7 +54,7 @@ export class TopicService {
 			.get(routes.view(context))
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
+				catchError(handleError)
 			);
 	}
 
@@ -63,7 +64,7 @@ export class TopicService {
 			.post(routes.create(context), context.entity)
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
+				catchError(handleError)
 			);
 	}
 
@@ -73,7 +74,7 @@ export class TopicService {
 			.put(routes.update(context), context.entity)
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
+				catchError(handleError)
 			);
 	}
 
@@ -83,7 +84,7 @@ export class TopicService {
 			.delete(routes.delete(context))
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
+				catchError(handleError)
 			);
 	}
 

--- a/src/app/core/http/vote/vote.service.ts
+++ b/src/app/core/http/vote/vote.service.ts
@@ -4,6 +4,7 @@ import { Observable, of } from 'rxjs';
 import { map, catchError } from 'rxjs/operators';
 
 import { Vote } from '@app/core/models/vote.model';
+import { handleError } from '@app/core/http/errors';
 
 const routes = {
 	list: (c: VoteContext) => `/votes`,
@@ -43,7 +44,7 @@ export class VoteService {
 			.get(routes.list(context), { params })
 			.pipe(
 				map((res: Array<any>) => res),
-				catchError((e) => of([{ error: e }]))
+				catchError(handleError)
 			);
 	}
 
@@ -53,7 +54,7 @@ export class VoteService {
 			.get(routes.view(context))
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
+				catchError(handleError)
 			);
 	}
 
@@ -62,7 +63,7 @@ export class VoteService {
 			.post(routes.create(context), context.entity)
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
+				catchError(handleError)
 			);
 	}
 
@@ -71,7 +72,7 @@ export class VoteService {
 			.put(routes.update(context), context.entity)
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
+				catchError(handleError)
 			);
 	}
 
@@ -80,7 +81,7 @@ export class VoteService {
 			.delete(routes.delete(context))
 			.pipe(
 				map((res: any) => res),
-				catchError((e) => of({ error: e }))
+				catchError(handleError)
 			);
 	}
 

--- a/src/app/core/models/state.model.ts
+++ b/src/app/core/models/state.model.ts
@@ -1,0 +1,8 @@
+export const enum AppState {
+    loading = 'loading',
+    loaded = 'loaded',
+    serverError = 'serverError',
+    error = 'error',
+    complete = 'complete'
+}
+

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,18 +1,20 @@
-<ng-container *ngIf="isLoading; then skeleton; else mainContainer">
+
+
+<ng-container *ngIf="loadingState === 'complete'; then mainContainer; else skeletonHeader">
 </ng-container>
 
-<ng-template #skeleton>
+<ng-template #skeletonHeader>
 	<app-skeleton-header>
 	</app-skeleton-header>
 </ng-template>
-
+	
 <ng-template #mainContainer>
 	<div fxLayout="column"
 		[@fadeIn]="!isLoading"
-	    fxLayoutAlign="center center"
-	    class="hero-image-container">
+		fxLayoutAlign="center center"
+		class="hero-image-container">
 		<div *ngIf="org"
-		    class="hero-image"
+			class="hero-image"
 			[defaultImage]="imageToPlaceholder(org.imageUrl)"
 			[lazyLoad]="org.imageUrl ?
 				replaceImageUrl(org.imageUrl)
@@ -27,24 +29,15 @@
 	</div>
 </ng-template>
 
-<ng-container *ngIf="isLoading; 
-	then skeletonCommunity; 
-	else mainCommunity">
-</ng-container>
-
-<ng-template #skeletonCommunity>
-	<div class="community-container container"
-		>
-			<div 
-				fxLayout="column"
-				>
+<ng-container [ngSwitch]="loadingState">
+	<div *ngSwitchCase="'loading'" class="community-container container">
+			<div fxLayout="column">
 				<div class="skeleton-title-wrap">
 					<app-skeleton-text-bar [isHeading]=true [width]="200">
 					</app-skeleton-text-bar>
 					<app-skeleton-text-bar [isSubtitle]=true [width]="150">
 					</app-skeleton-text-bar>
 				</div>
-
 				<div class="skeleton-triple-divider-container">
 					<div class="skeleton-triple-section">
 						<app-skeleton-text-bar [isHeading]=true [width]="25">
@@ -79,12 +72,23 @@
 					</app-skeleton-text-bar>
 				</div>
 			</div>
-
 	</div>
-</ng-template>
-
-<ng-template #mainCommunity>
-	<div [@fadeIn]="!isLoading" class="community-container container"
+	<div *ngSwitchCase="'serverError'" class="community-container container" fxLayoutAlign="center center">
+		<div fxFlex.gt-sm="690px" fxFlex.gt-md="800px" fxLayout="column">
+			<div class="mat-display-1 no-margin">
+				<span *ngIf="org">
+					Server Eror
+				</span>
+			</div>
+			<div class="mat-h2" *ngIf="org">
+				Could not load organization data.
+			</div>
+			<div>
+				<span class="mat-caption">Try refreshing the page, otherwise contact NewVote</span>
+			</div>
+		</div>
+	</div>
+	<div *ngSwitchCase="'complete'" [@fadeIn]=true class="community-container container"
 		fxLayoutAlign="center center">
 		<div fxFlex.gt-sm="690px"
 			fxFlex.gt-md="800px"
@@ -150,15 +154,11 @@
 			</div>
 		</div>
 	</div>
-</ng-template>
-
-<ng-container *ngIf="isLoading; 
-	then skeletonIssues; 
-	else mainIssues">
 </ng-container>
 
-<ng-template #skeletonIssues>
-	<div class="hot-issues-container container">
+
+<ng-container [ngSwitch]="loadingState">
+	<div *ngSwitchCase="'loading'" class="hot-issues-container container">
 		<div class="skeleton-issues-container">
 				<app-skeleton-text-bar class="skeleton-issue-header" [isSubtitle]="true" [width]="100">			
 				</app-skeleton-text-bar>
@@ -176,31 +176,63 @@
 			</div>
 		</div>
 	</div>
-</ng-template>
 
-<ng-template #mainIssues>
-	<div [@fadeIn]="isLoading" class="hot-issues-container container text-center"
-    	fxLayoutAlign="center center">
+	<div *ngSwitchCase="'serverError'" class="hot-issues-container container">
+			<div class="skeleton-issues-container">
+					<app-skeleton-text-bar class="skeleton-issue-header" [isSubtitle]="true" [width]="100">			
+					</app-skeleton-text-bar>
+				<div class="skeleton-card-list">
+					<app-skeleton-card>
+					</app-skeleton-card>
+					<app-skeleton-card>
+					</app-skeleton-card>
+					<app-skeleton-card>
+					</app-skeleton-card>
+				</div>
+				<div class="skeleton-issues-footer">
+					<app-skeleton-text-bar [isSubtitle]=true [width]="75">
+					</app-skeleton-text-bar>
+				</div>
+			</div>
+		</div>
+
+	<div *ngSwitchCase="'complete'" [@fadeIn]=true class="hot-issues-container container text-center"
+		fxLayoutAlign="center center">
 		<div fxFlex.gt-sm="690px"
 			fxFlex.gt-md="800px">
 			<h2 class="mat-h2">What's Hot?</h2>
-			<app-grid-list *ngIf="issues"
-				path="/issues"
-				model="Issue"
-				[itemLimit]="ISSUE_LIMIT"
-				[titleCard]=true
-				[items]=issues
-				(delete)="onDelete($event)"
-				(softDelete)="onSoftDelete($event)"></app-grid-list>
-			<div>
-				<button mat-button
-					routerLink="/issues">
-					SEE ALL ></button>
-			</div>
+			<ng-container *ngIf="issues.length < 1; then noIssues; else issuesExist">
+			</ng-container>
 		</div>
 	</div>
-</ng-template>
 
+	<ng-template #noIssues>
+		<h3 class="mat-h3">Currently there are no issues for this Organization</h3>
+			<div *ngIf="auth.isOwner() || auth.isAdmin()">
+				<p>Start engaging your community and create issues.</p>
+				<button mat-button
+					color="primary"
+					routerLink="/issues/create">
+					Create Issue
+				</button>
+			</div>
+	</ng-template>
+	<ng-template #issuesExist>
+		<app-grid-list *ngIf="issues"
+			path="/issues"
+			model="Issue"
+			[itemLimit]="ISSUE_LIMIT"
+			[titleCard]=true
+			[items]=issues
+			(delete)="onDelete($event)"
+			(softDelete)="onSoftDelete($event)"></app-grid-list>
+		<div>
+			<button mat-button
+				routerLink="/issues">
+				SEE ALL ></button>
+		</div>
+	</ng-template>
+</ng-container>
 
 <div class="about-community-container container text-center"
     fxLayoutAlign="center center"
@@ -212,10 +244,12 @@
 	</div>
 </div>
 
-<ng-container *ngIf="isLoading; 
+<ng-container *ngIf="loadingState !== 'complete'; 
 	then skeletonFooter; 
 	else mainFooter">
 </ng-container>
+
+<!-- Templates -->
 
 <ng-template #skeletonFooter>
 	<div class="final-container container">

--- a/src/app/issue/list/issue-list.component.html
+++ b/src/app/issue/list/issue-list.component.html
@@ -3,9 +3,8 @@
     [buttons]="headerButtons">
 </app-header-bar>
 
-<app-loader [isLoading]="isLoading"
+<app-loader [isLoading]="loadingState === 'loading'"
     size="1.5"></app-loader>
-
 
 <div class="container"
     fxLayout="row wrap"
@@ -13,142 +12,141 @@
 	<div fxFlex.gt-sm="690px"
 	    fxFlex.gt-md="800px">
 		<div>
-			<ng-container *ngIf="isLoading; 
-				then skeletonForm; 
-				else mainForm">
-			</ng-container>			
-			<ng-container *ngIf="isLoading;
-				then skeletonTopics; 
-				else mainTopics">
+			<ng-container [ngSwitch]="loadingState">
+					<div *ngSwitchCase="'loading'" class="skeleton-form-wrap">
+						<div class="skeleton-form">
+							<app-skeleton-text-bar 
+								[isSubtitle]=true [width]="110" 
+								[isMarginLess]=true> 
+							</app-skeleton-text-bar>
+						</div>
+					</div>
+					<mat-form-field
+						*ngSwitchCase="'complete'"
+						class="example-chip-list"
+						[@fadeIn]="!isLoading"
+						fxFill>
+						<mat-chip-list #chipList>
+							<mat-chip *ngFor="let topic of selectedTopics"
+								[selectable]="false"
+								[removable]="true"
+								(removed)="topicRemoved(topic)">
+								{{topic.name}}
+								<mat-icon matChipRemove>cancel</mat-icon>
+							</mat-chip>
+							<input placeholder="Filter Topics"
+								#topicInput
+								[formControl]="topicFilter"
+								[matAutocomplete]="auto"
+								[matChipInputFor]="chipList"
+								[matChipInputSeparatorKeyCodes]="separatorKeysCodes"
+								[matChipInputAddOnBlur]="true">
+						</mat-chip-list>
+						<mat-autocomplete #auto="matAutocomplete"
+							(optionSelected)="topicSelected($event)">
+							<mat-option *ngFor="let topic of filteredTopics | async"
+								[value]="topic">
+								{{topic.name}}
+							</mat-option>
+						</mat-autocomplete>
+					</mat-form-field>
+			</ng-container>
+		
+			<ng-container [ngSwitch]="loadingState">
+				<div *ngSwitchCase="'loading'">
+					<div class="skeleton-topic-wrap">
+						<div class="skeleton-form">
+							<app-skeleton-text-bar 
+								[isHeading]=true [width]="75" 
+								[isMarginLess]=true> 
+							</app-skeleton-text-bar>
+						</div>
+						<div class="skeleton-card-list">
+							<div class="skeleton-card">
+								<div  class="skeleton-card-image">
+								</div>
+								<div class="skeleton-card-content">
+									<app-skeleton-text-bar [isHeading]=true [width]="115">
+									</app-skeleton-text-bar>
+									<app-skeleton-text-bar [isSubtitle]=true [width]="145">
+									</app-skeleton-text-bar>
+								</div>
+							</div>
+							<div class="skeleton-card">
+								<div  class="skeleton-card-image">
+								</div>
+								<div class="skeleton-card-content">
+									<app-skeleton-text-bar [isHeading]=true [width]="115">
+									</app-skeleton-text-bar>
+									<app-skeleton-text-bar [isSubtitle]=true [width]="145">
+									</app-skeleton-text-bar>
+								</div>
+							</div>
+						</div>
+						<div class="skeleton-form">
+							<app-skeleton-text-bar 
+								[isHeading]=true [width]="125" 
+								[isMarginLess]=true> 
+							</app-skeleton-text-bar>
+						</div>
+						<div class="skeleton-card-list">
+							<div class="skeleton-card">
+								<div  class="skeleton-card-image">
+								</div>
+								<div class="skeleton-card-content">
+									<app-skeleton-text-bar [isHeading]=true [width]="115">
+									</app-skeleton-text-bar>
+									<app-skeleton-text-bar [isSubtitle]=true [width]="145">
+									</app-skeleton-text-bar>
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+				<div *ngSwitchCase="'serverError'">
+					<app-error-card>
+					</app-error-card>
+				</div>
+				<div *ngSwitchCase="'complete'">
+					<div [@fadeIn]=true 
+						*ngFor="let topic of (selectedTopics.length === 0 ? allTopics : selectedTopics)">
+						<h2 class="mat-h1">
+							{{topic.name}}
+							<div class="button-panel"
+								*ngIf="auth.isModerator(topic)">
+								<button color="accent"
+									mat-icon-button
+									[routerLink]="['/topics/edit', topic._id]">
+											<mat-icon aria-label="Edit the content">edit </mat-icon>
+								</button>
+								<button color="accent"
+									mat-icon-button
+									(click)="onSoftDeleteTopic(topic, $event)">
+											<mat-icon aria-label="Remove the content">delete</mat-icon>
+								</button>
+								<button color="warn"
+									mat-icon-button
+									*ngIf="auth.isAdmin(topic)"
+									(click)="onDeleteTopic(topic, $event)">
+											<mat-icon aria-label="Delete the content forever">delete_forever</mat-icon>
+								</button>
+							</div>
+							<mat-divider></mat-divider>
+						</h2>
+						<app-grid-list path="/issues"
+							[items]="getIssues(topic._id)"
+							model="Issue"
+							[titleCard]=true
+							(restore)="onRestore($event)"
+							(softDelete)="onSoftDelete($event)"
+							(delete)="onDelete($event)"></app-grid-list>
+						</div>
+					</div>
 			</ng-container>
 		</div>
 	</div>
 </div>
 
-<ng-template #skeletonForm>
-	<div class="skeleton-form-wrap">
-		<div class="skeleton-form">
-			<app-skeleton-text-bar 
-				[isSubtitle]=true [width]="110" 
-				[isMarginLess]=true> 
-			</app-skeleton-text-bar>
-		</div>
-	</div>
 
-</ng-template>
 
-<ng-template #mainForm>
-	<mat-form-field class="example-chip-list"
-		[@fadeIn]="!isLoading"
-		fxFill>
-		<mat-chip-list #chipList>
-			<mat-chip *ngFor="let topic of selectedTopics"
-				[selectable]="false"
-				[removable]="true"
-				(removed)="topicRemoved(topic)">
-				{{topic.name}}
-				<mat-icon matChipRemove>cancel</mat-icon>
-			</mat-chip>
-			<input placeholder="Filter Topics"
-				#topicInput
-				[formControl]="topicFilter"
-				[matAutocomplete]="auto"
-				[matChipInputFor]="chipList"
-				[matChipInputSeparatorKeyCodes]="separatorKeysCodes"
-				[matChipInputAddOnBlur]="true">
-		</mat-chip-list>
-		<mat-autocomplete #auto="matAutocomplete"
-			(optionSelected)="topicSelected($event)">
-			<mat-option *ngFor="let topic of filteredTopics | async"
-				[value]="topic">
-				{{topic.name}}
-			</mat-option>
-		</mat-autocomplete>
-	</mat-form-field>
-</ng-template>
 
-<ng-template #skeletonTopics>
-	<div class="skeleton-topic-wrap">
-		<div class="skeleton-form">
-			<app-skeleton-text-bar 
-				[isHeading]=true [width]="75" 
-				[isMarginLess]=true> 
-			</app-skeleton-text-bar>
-		</div>
-		<div class="skeleton-card-list">
-			<div class="skeleton-card">
-				<div  class="skeleton-card-image">
-				</div>
-				<div class="skeleton-card-content">
-					<app-skeleton-text-bar [isHeading]=true [width]="115">
-					</app-skeleton-text-bar>
-					<app-skeleton-text-bar [isSubtitle]=true [width]="145">
-					</app-skeleton-text-bar>
-				</div>
-			</div>
-			<div class="skeleton-card">
-				<div  class="skeleton-card-image">
-				</div>
-				<div class="skeleton-card-content">
-					<app-skeleton-text-bar [isHeading]=true [width]="115">
-					</app-skeleton-text-bar>
-					<app-skeleton-text-bar [isSubtitle]=true [width]="145">
-					</app-skeleton-text-bar>
-				</div>
-			</div>
-		</div>
-		<div class="skeleton-form">
-			<app-skeleton-text-bar 
-				[isHeading]=true [width]="125" 
-				[isMarginLess]=true> 
-			</app-skeleton-text-bar>
-		</div>
-		<div class="skeleton-card-list">
-			<div class="skeleton-card">
-				<div  class="skeleton-card-image">
-				</div>
-				<div class="skeleton-card-content">
-					<app-skeleton-text-bar [isHeading]=true [width]="115">
-					</app-skeleton-text-bar>
-					<app-skeleton-text-bar [isSubtitle]=true [width]="145">
-					</app-skeleton-text-bar>
-				</div>
-			</div>
-		</div>
-	</div>
-</ng-template>
-
-<ng-template #mainTopics>
-	<div [@fadeIn]="!isLoading" *ngFor="let topic of (selectedTopics.length === 0 ? allTopics : selectedTopics)">
-		<h2 class="mat-h1">
-			{{topic.name}}
-			<div class="button-panel"
-				*ngIf="auth.isModerator(topic)">
-				<button color="accent"
-					mat-icon-button
-					[routerLink]="['/topics/edit', topic._id]">
-							<mat-icon aria-label="Edit the content">edit </mat-icon>
-				</button>
-				<button color="accent"
-					mat-icon-button
-					(click)="onSoftDeleteTopic(topic, $event)">
-							<mat-icon aria-label="Remove the content">delete</mat-icon>
-				</button>
-				<button color="warn"
-					mat-icon-button
-					*ngIf="auth.isAdmin(topic)"
-					(click)="onDeleteTopic(topic, $event)">
-							<mat-icon aria-label="Delete the content forever">delete_forever</mat-icon>
-				</button>
-			</div>
-			<mat-divider></mat-divider>
-		</h2>
-		<app-grid-list path="/issues"
-			[items]="getIssues(topic._id)"
-			model="Issue"
-			[titleCard]=true
-			(restore)="onRestore($event)"
-			(softDelete)="onSoftDelete($event)"
-			(delete)="onDelete($event)"></app-grid-list>
-	</div>
-</ng-template>

--- a/src/app/issue/list/issue-list.component.html
+++ b/src/app/issue/list/issue-list.component.html
@@ -13,18 +13,19 @@
 	    fxFlex.gt-md="800px">
 		<div>
 			<ng-container [ngSwitch]="loadingState">
-					<div *ngSwitchCase="'loading'" class="skeleton-form-wrap">
-						<div class="skeleton-form">
-							<app-skeleton-text-bar 
-								[isSubtitle]=true [width]="110" 
-								[isMarginLess]=true> 
-							</app-skeleton-text-bar>
-						</div>
+				<div *ngSwitchCase="'loading'" class="skeleton-form-wrap">
+					<div class="skeleton-form">
+						<app-skeleton-text-bar 
+							[isSubtitle]=true [width]="110" 
+							[isMarginLess]=true> 
+						</app-skeleton-text-bar>
 					</div>
+				</div>
+				<div *ngSwitchCase="'complete'" >
 					<mat-form-field
-						*ngSwitchCase="'complete'"
+						*ngIf="allTopics.length > 0"
 						class="example-chip-list"
-						[@fadeIn]="!isLoading"
+						[@fadeIn]=true
 						fxFill>
 						<mat-chip-list #chipList>
 							<mat-chip *ngFor="let topic of selectedTopics"
@@ -34,7 +35,8 @@
 								{{topic.name}}
 								<mat-icon matChipRemove>cancel</mat-icon>
 							</mat-chip>
-							<input placeholder="Filter Topics"
+							<input 
+								placeholder="Filter Topics"
 								#topicInput
 								[formControl]="topicFilter"
 								[matAutocomplete]="auto"
@@ -50,6 +52,7 @@
 							</mat-option>
 						</mat-autocomplete>
 					</mat-form-field>
+				</div>
 			</ng-container>
 		
 			<ng-container [ngSwitch]="loadingState">
@@ -108,6 +111,18 @@
 					</app-error-card>
 				</div>
 				<div *ngSwitchCase="'complete'">
+					<ng-container *ngIf="allTopics.length === 0">
+						<div class="item-card-row"
+							fxFlex="100%"
+							>
+							<div class="empty-card-blank">
+							</div>
+							<div class="empty-title-container">
+								<h2 class="mat-h2">Topic's</h2>
+								<h4 class="mat-h4">There's no Topics to review at the moment.</h4>
+							</div>
+						</div>
+					</ng-container>		
 					<div [@fadeIn]=true 
 						*ngFor="let topic of (selectedTopics.length === 0 ? allTopics : selectedTopics)">
 						<h2 class="mat-h1">

--- a/src/app/issue/list/issue-list.component.scss
+++ b/src/app/issue/list/issue-list.component.scss
@@ -84,6 +84,28 @@ q {
 	flex-wrap: wrap;
 }
 
+.empty-card {
+	cursor: default;
+}
+
+.empty-card-blank {
+	margin-top: 3rem;
+	margin-left: auto;
+	margin-right: auto;
+	min-height: 200px;
+	max-height: 350px;
+	width: 50%;
+	background-image: url("assets/logo-no-text.png");
+	background-position: center;
+	background-repeat: no-repeat;
+	background-size: contain;
+	margin-bottom: 1rem;
+}
+
+.empty-title-container {
+	text-align: center;
+}
+
 @media only screen and (max-width: 600px) {
 
 	.skeleton-card-list {

--- a/src/app/organization/list/organization-list.component.ts
+++ b/src/app/organization/list/organization-list.component.ts
@@ -9,6 +9,8 @@ import { MetaService } from '@app/core/meta.service';
 
 import { IOrganization, Organization } from '@app/core/models/organization.model';
 import { Vote } from '@app/core/models/vote.model';
+import { StateService } from '@app/core/http/state/state.service';
+import { AppState } from '@app/core/models/state.model';
 
 @Component({
 	selector: 'app-organization',
@@ -27,8 +29,11 @@ export class OrganizationListComponent implements OnInit {
 		routerLink: '/communities/create',
 		role: 'admin'
 	}];
+	loadingState: string;
 
-	constructor(private organizationService: OrganizationService,
+	constructor(
+		private stateService: StateService,
+		private organizationService: OrganizationService,
 		private voteService: VoteService,
 		public auth: AuthenticationService,
 		private route: ActivatedRoute,
@@ -37,6 +42,10 @@ export class OrganizationListComponent implements OnInit {
 	) { }
 
 	ngOnInit() {
+		this.stateService.loadingState$.subscribe((state: string) => {
+			this.loadingState = state;
+		});
+
 		this.route.queryParamMap.subscribe(params => {
 			const force: boolean = !!params.get('forceUpdate');
 			this.fetchData(force);
@@ -50,13 +59,21 @@ export class OrganizationListComponent implements OnInit {
 
 	fetchData(force?: boolean) {
 		const isAdmin = this.auth.isAdmin();
-		this.isLoading = true;
+		this.stateService.setLoadingState(AppState.loading);
+
 		this.organizationService.list({
 			orgs: [], forceUpdate: force,
 			params: isAdmin ? { 'showDeleted': true } : {}
 		})
-			.pipe(finalize(() => { this.isLoading = false; }))
-			.subscribe(organizations => { this.organizations = organizations; });
+		.subscribe(
+			organizations => {
+				this.organizations = organizations;
+				return this.stateService.setLoadingState(AppState.complete);
+			},
+			(error) => {
+				return this.stateService.setLoadingState(AppState.serverError);
+			}
+		);
 	}
 
 	onDelete(event: any) {

--- a/src/app/organization/view/organization-view.component.ts
+++ b/src/app/organization/view/organization-view.component.ts
@@ -13,6 +13,8 @@ import { IOrganization } from '@app/core/models/organization.model';
 import { Organization } from '@app/core/models/organization.model';
 import { Vote } from '@app/core/models/vote.model';
 import { createUrl } from '@app/shared/helpers/cloudinary';
+import { StateService } from '@app/core/http/state/state.service';
+import { AppState } from '@app/core/models/state.model';
 
 @Component({
 	selector: 'app-organization',
@@ -24,8 +26,10 @@ export class OrganizationViewComponent implements OnInit {
 	organization: Organization;
 	organizations: Array<Organization>;
 	isLoading: boolean;
+	loadingState: string;
 
 	constructor(
+		private stateService: StateService,
 		private organizationService: OrganizationService,
 		private voteService: VoteService,
 		public auth: AuthenticationService,
@@ -37,7 +41,10 @@ export class OrganizationViewComponent implements OnInit {
 	) { }
 
 	ngOnInit() {
-		this.isLoading = true;
+		this.stateService.loadingState$.subscribe((state: string) => {
+			this.loadingState = state;
+		});
+
 		this.route.paramMap.subscribe(params => {
 			const ID = params.get('id');
 			this.getOrganization(ID);
@@ -45,16 +52,24 @@ export class OrganizationViewComponent implements OnInit {
 	}
 
 	getOrganization(id: string, forceUpdate?: boolean) {
+		this.stateService.setLoadingState(AppState.loading);
+
 		this.organizationService.view({ id: id, orgs: [], forceUpdate })
-			.pipe(finalize(() => { this.isLoading = false; }))
-			.subscribe((organization: Organization) => {
-				this.organization = organization;
-				this.meta.updateTags(
-					{
-						title: `${organization.name} Community`,
-						description: 'Viewing a community page.'
-					});
-			});
+			.subscribe(
+				(organization: Organization) => {
+					this.organization = organization;
+					this.meta.updateTags(
+						{
+							title: `${organization.name} Community`,
+							description: 'Viewing a community page.'
+						});
+					return this.stateService.setLoadingState(AppState.complete);
+
+				},
+				(error) => {
+					return this.stateService.setLoadingState(AppState.serverError);
+				}
+			)
 	}
 
 	onDelete() {

--- a/src/app/proposal/view/proposal-view.component.html
+++ b/src/app/proposal/view/proposal-view.component.html
@@ -1,24 +1,32 @@
 <app-loader [isLoading]="isLoading"
     size="1.5"></app-loader>
 
-<ng-container *ngIf="isLoading;
-	then skeletonHeader;
-	else mainHeader">
-</ng-container>
-
-<ng-template #skeletonHeader>
-	<app-skeleton-header [noLogo]=true >
-	</app-skeleton-header>
-	<app-skeleton-panel [hasVote]=true>
-	</app-skeleton-panel>
-</ng-template>
-
-<ng-template #mainHeader>
-	<mat-toolbar color="primary"
+<ng-container [ngSwitch]="loadingState">
+	<div *ngSwitchCase="'loading'">
+		<app-skeleton-header [noLogo]=true >
+		</app-skeleton-header>
+		<app-skeleton-panel [hasVote]=true>
+		</app-skeleton-panel>
+	</div>
+	<div *ngSwitchCase="'serverError'">
+		<app-skeleton-header [noLogo]=true >
+		</app-skeleton-header>
+		<app-skeleton-panel [hasVote]=true>
+		</app-skeleton-panel>
+		<div class="error-container">
+			<app-error-card>
+			</app-error-card>
+		</div>
+	</div>
+	<mat-toolbar 
+		*ngSwitchCase="'complete'"
+		color="primary"
 		[@fadeIn]="!isLoading"
 		class="header-info-panel"
-		*ngIf="proposal">
-		<div class="image-container"
+		>
+		<div 
+			*ngIf="proposal"
+			class="image-container"
 			fxLayout="column"
 			[defaultImage]="imageToPlaceholder(proposal.imageUrl)"
 			[lazyLoad]="proposal.imageUrl ?
@@ -102,8 +110,7 @@
 			</div>
 		</div>
 	</mat-toolbar>
-</ng-template>
-
+</ng-container>
 
 <div class="container"
     *ngIf="proposal"

--- a/src/app/proposal/view/proposal-view.component.scss
+++ b/src/app/proposal/view/proposal-view.component.scss
@@ -42,3 +42,8 @@ q {
 .buttons {
 	margin-bottom: 16px;
 }
+
+.error-container {
+	margin-top: 0.5rem;
+	padding: 0.5rem;
+}

--- a/src/app/shared/card-list/card-list.component.html
+++ b/src/app/shared/card-list/card-list.component.html
@@ -3,55 +3,37 @@
 <div fxLayout="column"
 	fxLayoutGap="32px"
 	*ngIf="items">
-	<ng-container *ngIf="isError;
-		then errorCard;
-		else mainCards">
+	<ng-container *ngIf="items.length === 0">
+		<div class="item-card-row"
+			fxFlex="100%"
+			>
+			<div class="empty-card-blank">
+			</div>
+			<div class="empty-title-container">
+				<h2 class="mat-h2">{{ model }}'s</h2>
+				<h4 class="mat-h4">There's no {{ model }} to review at the moment.</h4>
+			</div>
+		</div>
 	</ng-container>
-</div>
-
-<ng-template #errorCard>
 	<div class="item-card-row"
 		fxFlex="100%"
-		>
-		<mat-card class="item-card error-card">
-			<mat-card-content>
-				<mat-card-title translate>
-					<mat-icon aria-hidden="false" aria-label="Example home icon">error_outline</mat-icon>
-					We've run into an issue.
-				</mat-card-title>
-				<mat-card-subtitle class="item-subtitle">
-					We can't get what you are looking for. 
-				</mat-card-subtitle>
-				You can try refreshing the page otherwise try <a href="/contact">If you need a hand</a>.
-			</mat-card-content>
-		</mat-card>
-		<app-skeleton-wide-card
-			[showContent]=true
-		>
-		</app-skeleton-wide-card>	
-	</div>
-</ng-template>
-
-<ng-template #mainCards>
-	<div class="item-card-row"
-	    fxFlex="100%"
-	    *ngFor="let item of items">
+		*ngFor="let item of items">
 		<mat-card class="item-card"
 			[ngClass]="{'soft-deleted': item.softDeleted}"
-		    routerLink="{{path}}/{{item._id}}">
+			routerLink="{{path}}/{{item._id}}">
 			<div mat-card-image
-			    class="image-container"
+				class="image-container"
 				[ngStyle]="{'min-height': item.imageUrl ? '200px' : '0px'}"
 				[defaultImage]="imageToPlaceholder(item.imageUrl)"
 				[lazyLoad]="item.imageUrl ?
 					replaceImageUrl(item.imageUrl)
 				: ''">
 				<div class="button-panel"
-				    *ngIf="auth.isModerator() || auth.isCreator(item)">
+					*ngIf="auth.isModerator() || auth.isCreator(item)">
 					<button color="accent"
-					    mat-icon-button
-					    (click)="$event.stopPropagation()"
-					    routerLink='{{path}}/edit/{{item._id}}'>
+						mat-icon-button
+						(click)="$event.stopPropagation()"
+						routerLink='{{path}}/edit/{{item._id}}'>
 						<mat-icon aria-label="Edit the content">edit</mat-icon>
 					</button>
 					<button color="accent"
@@ -59,7 +41,7 @@
 						mat-icon-button
 						(click)="onRestore(item, $event)">
 						<mat-icon aria-label="Restore content">restore</mat-icon>
-				  	</button>
+					</button>
 					<button color="accent"
 						*ngIf="!item.softDeleted"
 						mat-icon-button
@@ -67,8 +49,8 @@
 					<mat-icon aria-label="Remove content">delete</mat-icon>
 				</button>
 					<button color="warn"
-					    mat-icon-button
-					    (click)="onDelete(item, $event)">
+						mat-icon-button
+						(click)="onDelete(item, $event)">
 						<mat-icon aria-label="Delete content forever">delete_forever</mat-icon>
 					</button>
 				</div>
@@ -80,7 +62,7 @@
 						<p *ngIf="showParent">This is a {{model}} for:
 							<span *ngFor="let parent of item[parentPropName]; let i = index">
 								<a (click)="$event.stopPropagation()"
-								    routerLink="{{parentPath}}/{{parent._id}}">{{parent.title || parent.name}}</a>
+									routerLink="{{parentPath}}/{{parent._id}}">{{parent.title || parent.name}}</a>
 								<span *ngIf="item[parentPropName].length > 1 && i !== item[parentPropName].length - 1">,&nbsp;</span>
 							</span>
 						</p>
@@ -92,35 +74,35 @@
 			</mat-card-content>
 			<mat-card-actions>
 				<app-vote-buttons [item]="item"
-				    (vote)=onVote($event)>
+					(vote)=onVote($event)>
 				</app-vote-buttons>
 			</mat-card-actions>
 			<div *ngIf="showChildren && item[childPath].length > 0"
-			    class="child-container">
+				class="child-container">
 				<span class="mat-card-title">{{childName}}</span>
 				<div *ngFor="let child of item[childPath]"
-				    routerLink="/{{childPath}}/{{child._id}}">
+					routerLink="/{{childPath}}/{{child._id}}">
 					<div class='mini-proposal'
 						[ngClass]="{'soft-deleted': child.softDeleted}"
 						>
 						<div fxLayout="column"
-						    class="point-area">
+							class="point-area">
 							<div fxLayout="row"
-							    fxLayoutAlign="start center">
+								fxLayoutAlign="start center">
 								<div class="mini-proposal-image"
-								    *ngIf="child.imageUrl"
+									*ngIf="child.imageUrl"
 									[defaultImage]="imageToPlaceholder(child.imageUrl)"
 									[lazyLoad]="child.imageUrl ?
 										replaceImageUrl(child.imageUrl)
 										: ''">
 								</div>
 								<div fxLayout="column"
-								    fxFlex>
+									fxFlex>
 									<span class="mat-title"
-									    [innerHtml]="child.title"></span>
+										[innerHtml]="child.title"></span>
 									<app-vote-buttons class="buttons"
-									    [item]="child"
-									    (vote)=onChildVote($event)>
+										[item]="child"
+										(vote)=onChildVote($event)>
 									</app-vote-buttons>
 								</div>
 							</div>
@@ -130,4 +112,7 @@
 			</div>
 		</mat-card>
 	</div>
-</ng-template>
+</div>
+
+
+

--- a/src/app/shared/card-list/card-list.component.html
+++ b/src/app/shared/card-list/card-list.component.html
@@ -1,6 +1,38 @@
+
+
 <div fxLayout="column"
-    fxLayoutGap="32px"
-    *ngIf="items">
+	fxLayoutGap="32px"
+	*ngIf="items">
+	<ng-container *ngIf="isError;
+		then errorCard;
+		else mainCards">
+	</ng-container>
+</div>
+
+<ng-template #errorCard>
+	<div class="item-card-row"
+		fxFlex="100%"
+		>
+		<mat-card class="item-card error-card">
+			<mat-card-content>
+				<mat-card-title translate>
+					<mat-icon aria-hidden="false" aria-label="Example home icon">error_outline</mat-icon>
+					We've run into an issue.
+				</mat-card-title>
+				<mat-card-subtitle class="item-subtitle">
+					We can't get what you are looking for. 
+				</mat-card-subtitle>
+				You can try refreshing the page otherwise try <a href="/contact">If you need a hand</a>.
+			</mat-card-content>
+		</mat-card>
+		<app-skeleton-wide-card
+			[showContent]=true
+		>
+		</app-skeleton-wide-card>	
+	</div>
+</ng-template>
+
+<ng-template #mainCards>
 	<div class="item-card-row"
 	    fxFlex="100%"
 	    *ngFor="let item of items">
@@ -98,4 +130,4 @@
 			</div>
 		</mat-card>
 	</div>
-</div>
+</ng-template>

--- a/src/app/shared/card-list/card-list.component.scss
+++ b/src/app/shared/card-list/card-list.component.scss
@@ -28,6 +28,28 @@
 	cursor: default;
 }
 
+.empty-card {
+	cursor: default;
+}
+
+.empty-card-blank {
+	margin-top: 3rem;
+	margin-left: auto;
+	margin-right: auto;
+	min-height: 200px;
+	max-height: 350px;
+	width: 50%;
+	background-image: url("assets/logo-no-text.png");
+	background-position: center;
+	background-repeat: no-repeat;
+	background-size: contain;
+	margin-bottom: 1rem;
+}
+
+.empty-title-container {
+	text-align: center;
+}
+
 .status {
 	text-decoration: underline;
 }

--- a/src/app/shared/card-list/card-list.component.scss
+++ b/src/app/shared/card-list/card-list.component.scss
@@ -22,6 +22,12 @@
 	cursor: pointer;
 }
 
+.error-card {
+	margin-bottom: 32px;
+	border: 1px solid red;
+	cursor: default;
+}
+
 .status {
 	text-decoration: underline;
 }

--- a/src/app/shared/card-list/card-list.component.ts
+++ b/src/app/shared/card-list/card-list.component.ts
@@ -21,6 +21,7 @@ export class CardListComponent implements OnInit {
 	@Input() showParent = false;
 	@Input() parentPath: string;
 	@Input() parentPropName: string;
+	@Input() isError: boolean;
 	@Output() restore = new EventEmitter();
 	@Output() softDelete = new EventEmitter();
 	@Output() delete = new EventEmitter();

--- a/src/app/shared/error/error-card/error-card.component.html
+++ b/src/app/shared/error/error-card/error-card.component.html
@@ -1,0 +1,20 @@
+<div class="item-card-row"
+  fxFlex="100%"
+  >
+  <mat-card class="item-card error-card">
+    <mat-card-content>
+      <mat-card-title>
+        <mat-icon aria-hidden="false" aria-label="Example home icon">error_outline</mat-icon>
+        We've run into an issue.
+      </mat-card-title>
+      <mat-card-subtitle class="item-subtitle">
+        We can't get what you are looking for. 
+      </mat-card-subtitle>
+      You can try refreshing the page otherwise try <a href="/contact">If you need a hand</a>.
+    </mat-card-content>
+  </mat-card>
+  <app-skeleton-wide-card
+    [showContent]=true
+  >
+  </app-skeleton-wide-card>	
+</div>

--- a/src/app/shared/error/error-card/error-card.component.spec.ts
+++ b/src/app/shared/error/error-card/error-card.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ErrorCardComponent } from './error-card.component';
+
+describe('ErrorCardComponent', () => {
+  let component: ErrorCardComponent;
+  let fixture: ComponentFixture<ErrorCardComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ErrorCardComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ErrorCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/error/error-card/error-card.component.ts
+++ b/src/app/shared/error/error-card/error-card.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-error-card',
+  templateUrl: './error-card.component.html',
+  styleUrls: ['./error-card.component.scss']
+})
+export class ErrorCardComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -35,6 +35,7 @@ import { SkeletonCardComponent } from './skeleton/skeleton-card/skeleton-card.co
 import { SkeletonPanelComponent } from './skeleton/skeleton-panel/skeleton-panel.component';
 
 import { LazyLoadImageModule, intersectionObserverPreset } from 'ng-lazyload-image';
+import { ErrorCardComponent } from './error/error-card/error-card.component';
 
 @NgModule({
 	imports: [
@@ -76,7 +77,8 @@ import { LazyLoadImageModule, intersectionObserverPreset } from 'ng-lazyload-ima
 		SkeletonChildCardComponent,
 		SkeletonMediaCardComponent,
 		SkeletonCardComponent,
-		SkeletonPanelComponent
+		SkeletonPanelComponent,
+		ErrorCardComponent
 	],
 	exports: [
 		LoaderComponent,
@@ -99,7 +101,8 @@ import { LazyLoadImageModule, intersectionObserverPreset } from 'ng-lazyload-ima
 		SkeletonChildCardComponent,
 		SkeletonMediaCardComponent,
 		SkeletonCardComponent,
-		SkeletonPanelComponent
+		SkeletonPanelComponent,
+		ErrorCardComponent
 	]
 })
 export class SharedModule { }

--- a/src/app/solution/list/solution-list.component.html
+++ b/src/app/solution/list/solution-list.component.html
@@ -3,7 +3,7 @@
     [buttons]="headerButtons">
 </app-header-bar>
 
-<app-loader [isLoading]="isLoading"
+<app-loader [isLoading]="loadingState === 'loading'"
     size="1.5">
 </app-loader>
 
@@ -13,62 +13,62 @@
     fxLayoutAlign="center start">
 	<div fxFlex.gt-sm="690px"
 	    fxFlex.gt-md="800px">
-		<ng-container 
-			*ngIf="isLoading;
-			then skeletonSolutions;
-			else mainSolutions">
+		<ng-container [ngSwitch]="loadingState">
+				<div 
+					*ngSwitchCase="'loading'"
+					class="container"
+					fxLayout="column"
+					fxLayoutAlign="center start"
+					>
+					<div class="skeleton-card-list"
+						>
+						<!-- <app-skeleton-text-bar [isSubtitle]=true [width]="150">
+						</app-skeleton-text-bar> -->
+			
+						<app-skeleton-wide-card
+							[showImage]=true
+							[showContent]=true
+							[showActions]=true
+							[showChildren]=true
+						>
+						</app-skeleton-wide-card>
+						<app-skeleton-wide-card
+							[showImage]=true
+							[showContent]=true
+							[showActions]=true
+						>
+						</app-skeleton-wide-card>
+						<app-skeleton-wide-card
+							[showImage]=true
+							[showContent]=true
+							[showActions]=true
+						>
+						</app-skeleton-wide-card>
+					</div>	
+				</div>
+			<app-error-card *ngSwitchCase="'serverError'">
+			</app-error-card>
+			<app-card-list 
+				*ngSwitchCase="'complete'"
+				path="/solutions"
+				[@fadeIn]=true
+				[items]=solutions
+				model="Solution"
+				[showChildren]="true"
+				childPath="proposals"
+				childName="Actions"
+				[showParent]="true"
+				parentPath="/issues"
+				parentPropName="issues"
+				(restore)="onRestore($event)"
+				(softDelete)="onSoftDelete($event)"
+				(delete)="onDelete($event)"
+				(vote)="onVote($event, 'Solution')"
+				(childVote)="onVote($event, 'Proposal')">
+			</app-card-list>
 		</ng-container>
 	</div>
 </div>
 
-<ng-template #skeletonSolutions>
-	<div class="container"
-		fxLayout="column"
-		fxLayoutAlign="center start"
-		>
-		<div class="skeleton-card-list"
-			>
-			<app-skeleton-text-bar [isSubtitle]=true [width]="150">
-			</app-skeleton-text-bar>
 
-			<app-skeleton-wide-card
-				[showImage]=true
-				[showContent]=true
-				[showActions]=true
-				[showChildren]=true
-			>
-			</app-skeleton-wide-card>
-			<app-skeleton-wide-card
-				[showImage]=true
-				[showContent]=true
-				[showActions]=true
-			>
-			</app-skeleton-wide-card>
-			<app-skeleton-wide-card
-				[showImage]=true
-				[showContent]=true
-				[showActions]=true
-			>
-			</app-skeleton-wide-card>
-		</div>	
-	</div>
-</ng-template>
 
-<ng-template #mainSolutions>
-	<app-card-list path="/solutions"
-		[@fadeIn]="!isLoading"
-		[items]=solutions
-		model="Solution"
-		[showChildren]="true"
-		childPath="proposals"
-		childName="Actions"
-		[showParent]="true"
-		parentPath="/issues"
-		parentPropName="issues"
-		(restore)="onRestore($event)"
-		(softDelete)="onSoftDelete($event)"
-		(delete)="onDelete($event)"
-		(vote)="onVote($event, 'Solution')"
-		(childVote)="onVote($event, 'Proposal')">
-	</app-card-list>
-</ng-template>

--- a/src/app/solution/list/solution-list.component.ts
+++ b/src/app/solution/list/solution-list.component.ts
@@ -15,6 +15,8 @@ import { Vote } from '@app/core/models/vote.model';
 
 import { trigger } from '@angular/animations';
 import { fadeIn } from '@app/shared/animations/fade-animations';
+import { StateService } from '@app/core/http/state/state.service';
+import { AppState } from '@app/core/models/state.model';
 
 @Component({
 	selector: 'app-solution',
@@ -26,6 +28,7 @@ import { fadeIn } from '@app/shared/animations/fade-animations';
 })
 export class SolutionListComponent implements OnInit {
 
+	loadingState: string;
 	solutions: Array<any>;
 	isLoading: boolean;
 	headerTitle = 'Browse By Solution';
@@ -37,7 +40,9 @@ export class SolutionListComponent implements OnInit {
 		role: 'admin'
 	}];
 
-	constructor(private solutionService: SolutionService,
+	constructor(
+		private stateService: StateService,
+		private solutionService: SolutionService,
 		private voteService: VoteService,
 		public auth: AuthenticationService,
 		private route: ActivatedRoute,
@@ -47,19 +52,22 @@ export class SolutionListComponent implements OnInit {
 	) { }
 
 	ngOnInit() {
-	this.meta.updateTags(
-		{
-			title: 'All Solutions',
-			description: 'Solutions are the decisions that you think your community should make.'
+		this.stateService.loadingState$.subscribe((state: string) => {
+			this.loadingState = state;
 		});
-		this.route.queryParamMap.subscribe(params => {
-			const force: boolean = !!params.get('forceUpdate');
-			this.fetchData(force);
-		});
+		this.stateService.setLoadingState(AppState.loading);
+		this.meta.updateTags(
+			{
+				title: 'All Solutions',
+				description: 'Solutions are the decisions that you think your community should make.'
+			});
+			this.route.queryParamMap.subscribe(params => {
+				const force: boolean = !!params.get('forceUpdate');
+				this.fetchData(force);
+			});
 	}
 
 	fetchData(force?: boolean) {
-		this.isLoading = true;
 		const isOwner = this.auth.isOwner();
 
 		this.solutionService.list({
@@ -67,10 +75,15 @@ export class SolutionListComponent implements OnInit {
 			forceUpdate: force,
 			params: isOwner ? { 'showDeleted': true } :  {}
 		})
-			.pipe(finalize(() => { this.isLoading = false; }))
-			.subscribe(solutions => {
-				this.solutions = solutions.sort((a: Solution, b: Solution) => b.votes.up - a.votes.up);
-			});
+			.subscribe(
+				solutions => {
+					this.solutions = solutions.sort((a: Solution, b: Solution) => b.votes.up - a.votes.up);
+					return 	this.stateService.setLoadingState(AppState.complete);
+				},
+				err => {
+					return this.stateService.setLoadingState(AppState.serverError);
+				}
+			)
 	}
 
 	// find the different solution and only update it, not entire list
@@ -78,19 +91,24 @@ export class SolutionListComponent implements OnInit {
 	refreshData() {
 		const isOwner = this.auth.isOwner();
 
-		this.isLoading = true;
+		this.stateService.setLoadingState(AppState.loading);
 		this.solutionService.list({
 			orgs: [],
 			forceUpdate: true,
 			params: isOwner ? { 'showDeleted': true } :  {} })
-			.pipe(finalize(() => { this.isLoading = false; }))
-			.subscribe(solutions => {
-				const diff = _differenceWith(solutions, this.solutions, _isEqual);
-				if (diff.length > 0) {
-					const index = this.solutions.findIndex(s => s._id === diff[0]._id);
-					this.solutions[index] = diff[0];
+			.subscribe(
+				solutions => {
+					const diff = _differenceWith(solutions, this.solutions, _isEqual);
+					if (diff.length > 0) {
+						const index = this.solutions.findIndex(s => s._id === diff[0]._id);
+						this.solutions[index] = diff[0];
+					}
+					return 	this.stateService.setLoadingState(AppState.complete);
+				},
+				error => {
+					return this.stateService.setLoadingState(AppState.serverError);
 				}
-			});
+			);
 	}
 
 	onRestore(event: any) {

--- a/src/app/solution/view/solution-view.component.html
+++ b/src/app/solution/view/solution-view.component.html
@@ -147,8 +147,16 @@
 			</app-skeleton-wide-card>
 		</div>	
 	</div>
-	<app-error-card *ngSwitchCase="'serverError'">
-	</app-error-card>
+	<div 
+		*ngSwitchCase="'serverError'"
+		class="container"
+		fxLayout="column"
+		fxLayoutAlign="center center"
+		>
+		<app-error-card >
+		</app-error-card>
+	</div>
+	
 	<div 
 		*ngSwitchCase="'complete'"
 		class="container"

--- a/src/app/solution/view/solution-view.component.html
+++ b/src/app/solution/view/solution-view.component.html
@@ -1,63 +1,28 @@
 <app-loader [isLoading]="isLoading"
     size="1.5"></app-loader>
 
-<ng-container 
-	*ngIf="isLoading;
-	then skeletonHeader;
-	else mainHeader">
-</ng-container>
-
-<ng-container *ngIf="isLoading;
-	then skeletonSolutions;
-	else mainSolutions">
-</ng-container>
-
-<ng-template #skeletonHeader>
-	<app-skeleton-header [noLogo]=true >
-	</app-skeleton-header>
-	<app-skeleton-panel [hasVote]=true>
-	</app-skeleton-panel>
-</ng-template>
-
-<ng-template #skeletonSolutions>
-	<div class="container"
-		fxLayout="column"
-		fxLayoutAlign="center start"
-		>
-		<div class="skeleton-card-list"
-			>
-			<app-skeleton-text-bar [isSubtitle]=true [width]="150">
-			</app-skeleton-text-bar>
-
-			<app-skeleton-wide-card
-				[showImage]=true
-				[showContent]=true
-				[showActions]=true
-				[showChildren]=true
-			>
-			</app-skeleton-wide-card>
-			<app-skeleton-wide-card
-				[showImage]=true
-				[showContent]=true
-				[showActions]=true
-			>
-			</app-skeleton-wide-card>
-			<app-skeleton-wide-card
-				[showImage]=true
-				[showContent]=true
-				[showActions]=true
-			>
-			</app-skeleton-wide-card>
-		</div>	
+<ng-container [ngSwitch]="loadingState">
+	<div *ngSwitchCase="'loading'">
+		<app-skeleton-header [noLogo]=true >
+		</app-skeleton-header>
+		<app-skeleton-panel [hasVote]=true>
+		</app-skeleton-panel>
 	</div>
-</ng-template>
-
-<ng-template #mainHeader>
-	<mat-toolbar color="primary"
-		[@fadeIn]="!isLoading"
+	<div *ngSwitchCase="'serverError'">
+		<app-skeleton-header [noLogo]=true >
+		</app-skeleton-header>
+		<app-skeleton-panel [hasVote]=true>
+		</app-skeleton-panel>
+	</div>
+	<mat-toolbar 
+		color="primary"
+		*ngSwitchCase="'complete'"
+		[@fadeIn]=true
 		class="header-info-panel"
-		*ngIf="solution">
-		<div class="image-container"
+		>
+		<div 
+			*ngIf="solution"
+			class="image-container"
 			fxLayout="column"
 			[defaultImage]="imageToPlaceholder(solution.imageUrl)"
 			[lazyLoad]="solution.imageUrl ?
@@ -147,16 +112,52 @@
 			</div>
 		</div>
 	</mat-toolbar>
-</ng-template>
+</ng-container>
 
+<ng-container [ngSwitch]="loadingState">
+	<div 
+		*ngSwitchCase="'loading'"
+		class="container"
+		fxLayout="column"
+		fxLayoutAlign="center start"
+		>
+		<div class="skeleton-card-list"
+			>
+			<app-skeleton-text-bar [isSubtitle]=true [width]="150">
+			</app-skeleton-text-bar>
 
-<ng-template #mainSolutions>
-	<div class="container"
-		[@fadeIn]="!isLoading"
-		*ngIf="solution"
+			<app-skeleton-wide-card
+				[showImage]=true
+				[showContent]=true
+				[showActions]=true
+				[showChildren]=true
+			>
+			</app-skeleton-wide-card>
+			<app-skeleton-wide-card
+				[showImage]=true
+				[showContent]=true
+				[showActions]=true
+			>
+			</app-skeleton-wide-card>
+			<app-skeleton-wide-card
+				[showImage]=true
+				[showContent]=true
+				[showActions]=true
+			>
+			</app-skeleton-wide-card>
+		</div>	
+	</div>
+	<app-error-card *ngSwitchCase="'serverError'">
+	</app-error-card>
+	<div 
+		*ngSwitchCase="'complete'"
+		class="container"
+		[@fadeIn]=true
 		fxLayout="row wrap"
 		fxLayoutAlign="center start">
-		<div fxFlex.gt-sm="690px"
+		<div 
+			*ngIf="solution"
+			fxFlex.gt-sm="690px"
 			fxFlex.gt-md="800px">
 			<span class="mat-headline" *ngIf="solution && solution.proposals && solution.proposals.length > 0">Vote on Actions</span>
 			<app-card-list path="/proposals"
@@ -172,4 +173,13 @@
 				(vote)="onVote($event, 'Proposal')"></app-card-list>
 		</div>
 	</div>
-</ng-template>
+</ng-container>
+
+
+
+
+
+
+
+
+

--- a/src/app/solution/view/solution-view.component.html
+++ b/src/app/solution/view/solution-view.component.html
@@ -153,8 +153,12 @@
 		fxLayout="column"
 		fxLayoutAlign="center center"
 		>
-		<app-error-card >
-		</app-error-card>
+		<div
+		fxFlex.gt-sm="690px"
+			fxFlex.gt-md="800px">
+			<app-error-card >
+			</app-error-card>
+		</div>
 	</div>
 	
 	<div 

--- a/src/app/solution/view/solution-view.component.ts
+++ b/src/app/solution/view/solution-view.component.ts
@@ -16,6 +16,8 @@ import { ProposalService } from '@app/core/http/proposal/proposal.service';
 import { createUrl } from '@app/shared/helpers/cloudinary';
 import { trigger } from '@angular/animations';
 import { fadeIn } from '@app/shared/animations/fade-animations';
+import { StateService } from '@app/core/http/state/state.service';
+import { AppState } from '@app/core/models/state.model';
 
 @Component({
 	selector: 'app-solution',
@@ -29,8 +31,9 @@ export class SolutionViewComponent implements OnInit {
 
 	solution: Solution;
 	isLoading: boolean;
-
+	loadingState: string;
 	constructor(
+		private stateService: StateService,
 		private solutionService: SolutionService,
 		private voteService: VoteService,
 		private proposalService: ProposalService,
@@ -43,7 +46,11 @@ export class SolutionViewComponent implements OnInit {
 	) { }
 
 	ngOnInit() {
-		this.isLoading = true;
+		// this.isLoading = true;
+		this.stateService.loadingState$.subscribe((state: string) => {
+			this.loadingState = state;
+		});
+
 		this.route.paramMap.subscribe(params => {
 			const ID = params.get('id');
 			this.getSolution(ID);
@@ -52,6 +59,7 @@ export class SolutionViewComponent implements OnInit {
 
 	getSolution(id: string, forceUpdate?: boolean) {
 		const isOwner = this.auth.isOwner();
+		this.stateService.setLoadingState(AppState.loading);
 
 		this.solutionService.view({
 			id: id,
@@ -59,8 +67,8 @@ export class SolutionViewComponent implements OnInit {
 			forceUpdate,
 			params: isOwner ? { 'showDeleted': true } :  {}
 		})
-			.pipe(finalize(() => { this.isLoading = false; }))
-			.subscribe((solution: Solution) => {
+		.subscribe(
+			(solution: Solution) => {
 				this.solution = solution;
 				this.solution.imageUrl = this.replaceImageUrl(this.solution.imageUrl);
 				this.meta.updateTags(
@@ -70,7 +78,13 @@ export class SolutionViewComponent implements OnInit {
 						description: solution.description,
 						image: solution.imageUrl
 					});
-			});
+
+				return this.stateService.setLoadingState(AppState.complete);
+			},
+			(err) => {
+				return this.stateService.setLoadingState(AppState.serverError);
+			}
+		);
 	}
 
 	onVote(voteData: any, model: string) {
@@ -83,18 +97,21 @@ export class SolutionViewComponent implements OnInit {
 			vote.voteValue = existingVote.voteValue === voteValue ? 0 : voteValue;
 		}
 
-		this.voteService.create({ entity: vote }).subscribe((res) => {
-			if (res.error) {
-				if (res.error.status === 401) {
-					this.openSnackBar('You must be logged in to vote', 'OK');
-				} else {
-					this.openSnackBar('There was an error recording your vote', 'OK');
+		this.voteService.create({ entity: vote })
+			.subscribe(
+				(res) => {
+					this.openSnackBar('Your vote was recorded', 'OK');
+					this.getSolution(this.solution._id, true);
+				},
+				(error) => {
+					console.log(error, 'this is error');
+					if (error.status === 401) {
+						this.openSnackBar('You must be logged in to vote', 'OK');
+					} else {
+						this.openSnackBar('There was an error recording your vote', 'OK');
+					}
 				}
-			} else {
-				this.openSnackBar('Your vote was recorded', 'OK');
-				this.getSolution(this.solution._id, true);
-			}
-		});
+			);
 	}
 
 	onDelete() {

--- a/src/app/suggestion/list/suggestion-list.component.html
+++ b/src/app/suggestion/list/suggestion-list.component.html
@@ -3,7 +3,7 @@
     [buttons]="headerButtons">
 </app-header-bar>
 
-<app-loader [isLoading]="isLoading"
+<app-loader [isLoading]="loadingState === 'loading'"
     size="1.5">
 </app-loader>
 
@@ -12,48 +12,48 @@
     fxLayoutAlign="center start">
 	<div fxFlex.gt-sm="690px"
 	    fxFlex.gt-md="800px">
-		<ng-container *ngIf="isLoading;
-			then skeletonSuggestions;
-			else mainSuggestions">
+		<ng-container [ngSwitch]="loadingState">
+			<div 
+				*ngSwitchCase="'loading'"
+				class="container"
+				fxLayout="column"
+				fxLayoutAlign="center start"
+				>
+				<div class="skeleton-card-list">
+					<app-skeleton-wide-card
+						[showContent]=true
+						[showActions]=true
+					>
+					</app-skeleton-wide-card>
+					<app-skeleton-wide-card
+						[showContent]=true
+						[showActions]=true
+					>
+					</app-skeleton-wide-card>
+					<app-skeleton-wide-card
+						[showContent]=true
+						[showActions]=true
+					>
+					</app-skeleton-wide-card>
+				</div>
+			</div>
+			<app-error-card *ngSwitchCase="'serverError'">
+			</app-error-card>
+			<app-card-list 
+				*ngSwitchCase="'complete'"
+				path="/suggestions"
+				[@fadeIn]="loadingState === 'complete'"
+				[items]=suggestions
+				model="Suggestion"
+				(restore)="onRestore($event)"
+				(softDelete)="onSoftDelete($event)"
+				(delete)="onDelete($event)"
+				(vote)="onVote($event)"></app-card-list>
 		</ng-container>
 	</div>
 </div>
 
-<!-- /* Template */ -->
-<ng-template #skeletonSuggestions>
-	<div class="container"
-		fxLayout="column"
-		fxLayoutAlign="center start"
-		>
-		<div class="skeleton-card-list">
-			<app-skeleton-wide-card
-				[showContent]=true
-				[showActions]=true
-			>
-			</app-skeleton-wide-card>
-			<app-skeleton-wide-card
-				[showContent]=true
-				[showActions]=true
-			>
-			</app-skeleton-wide-card>
-			<app-skeleton-wide-card
-				[showContent]=true
-				[showActions]=true
-			>
-			</app-skeleton-wide-card>
-		</div>
-	</div>
-</ng-template>
 
-<ng-template #mainSuggestions>
-	<app-card-list 
-		path="/suggestions"
-		[@fadeIn]="!isLoading"
-		[isError]="suggestions[0].error"
-		[items]=suggestions
-		model="Suggestion"
-		(restore)="onRestore($event)"
-		(softDelete)="onSoftDelete($event)"
-		(delete)="onDelete($event)"
-		(vote)="onVote($event)"></app-card-list>
-</ng-template>
+
+
+

--- a/src/app/suggestion/list/suggestion-list.component.html
+++ b/src/app/suggestion/list/suggestion-list.component.html
@@ -46,8 +46,10 @@
 </ng-template>
 
 <ng-template #mainSuggestions>
-	<app-card-list path="/suggestions"
+	<app-card-list 
+		path="/suggestions"
 		[@fadeIn]="!isLoading"
+		[isError]="suggestions[0].error"
 		[items]=suggestions
 		model="Suggestion"
 		(restore)="onRestore($event)"

--- a/src/app/suggestion/list/suggestion-list.component.ts
+++ b/src/app/suggestion/list/suggestion-list.component.ts
@@ -65,8 +65,14 @@ export class SuggestionListComponent implements OnInit {
 			forceUpdate: force,
 			params: isOwner ? { 'showDeleted': true } :  {}
 		})
-			.pipe(finalize(() => { this.isLoading = false; }))
-			.subscribe(suggestions => { this.suggestions = suggestions; });
+		.pipe(finalize(() => { this.isLoading = false; }))
+		.subscribe(
+			suggestions => {
+				console.log(suggestions, 'this is suggestions');
+				this.suggestions = suggestions;
+			},
+			err => { console.log(err, 'this is err'); }
+			);
 	}
 
 	onDelete(event: any) {

--- a/src/app/suggestion/list/suggestion-list.component.ts
+++ b/src/app/suggestion/list/suggestion-list.component.ts
@@ -13,6 +13,8 @@ import { Vote } from '@app/core/models/vote.model';
 
 import { trigger } from '@angular/animations';
 import { fadeIn } from '@app/shared/animations/fade-animations';
+import { StateService } from '@app/core/http/state/state.service';
+import { AppState } from '@app/core/models/state.model';
 
 @Component({
 	selector: 'app-suggestion',
@@ -24,6 +26,7 @@ import { fadeIn } from '@app/shared/animations/fade-animations';
 })
 export class SuggestionListComponent implements OnInit {
 
+	loadingState: string;
 	suggestions: Array<any>;
 	isLoading: boolean;
 	headerTitle = 'Make a new contribution';
@@ -38,6 +41,7 @@ export class SuggestionListComponent implements OnInit {
 	}];
 
 	constructor(private suggestionService: SuggestionService,
+		private stateService: StateService,
 		private voteService: VoteService,
 		public auth: AuthenticationService,
 		private route: ActivatedRoute,
@@ -47,6 +51,10 @@ export class SuggestionListComponent implements OnInit {
 	) { }
 
 	ngOnInit() {
+		this.stateService.loadingState$.subscribe((state: string) => {
+			this.loadingState = state;
+		})
+
 		this.route.queryParamMap.subscribe(params => {
 			const force: boolean = !!params.get('forceUpdate');
 			this.fetchData(force);
@@ -60,19 +68,20 @@ export class SuggestionListComponent implements OnInit {
 
 	fetchData(force?: boolean) {
 		const isOwner = this.auth.isOwner();
-		this.isLoading = true;
+		this.stateService.setLoadingState(AppState.loading);
 		this.suggestionService.list({
 			forceUpdate: force,
 			params: isOwner ? { 'showDeleted': true } :  {}
 		})
-		.pipe(finalize(() => { this.isLoading = false; }))
 		.subscribe(
 			suggestions => {
-				console.log(suggestions, 'this is suggestions');
 				this.suggestions = suggestions;
+				this.stateService.setLoadingState(AppState.complete);
 			},
-			err => { console.log(err, 'this is err'); }
-			);
+			err => {
+				return this.stateService.setLoadingState(AppState.serverError);
+			}
+		);
 	}
 
 	onDelete(event: any) {
@@ -109,18 +118,19 @@ export class SuggestionListComponent implements OnInit {
 			vote.voteValue = existingVote.voteValue === voteValue ? 0 : voteValue;
 		}
 
-		this.voteService.create({ entity: vote }).subscribe((res) => {
-			if (res.error) {
-				if (res.error.status === 401) {
+		this.voteService.create({ entity: vote })
+			.subscribe((res) => {
+				this.openSnackBar('Your vote was recorded', 'OK');
+				this.fetchData(true);
+			},
+			(error) => {
+				if (error.status === 401) {
 					this.openSnackBar('You must be logged in to vote', 'OK');
 				} else {
 					this.openSnackBar('There was an error recording your vote', 'OK');
 				}
-			} else {
-				this.openSnackBar('Your vote was recorded', 'OK');
-				this.fetchData(true);
 			}
-		});
+		);
 	}
 
 	openSnackBar(message: string, action: string) {

--- a/src/app/suggestion/view/suggestion-view.component.html
+++ b/src/app/suggestion/view/suggestion-view.component.html
@@ -4,6 +4,8 @@
 <ng-container [ngSwitch]="loadingState">
 	<app-skeleton-panel *ngSwitchCase="'loading'" [hasVote]=true>
 	</app-skeleton-panel>
+	<app-skeleton-panel *ngSwitchCase="'serverError'" [hasVote]=true>
+	</app-skeleton-panel>
 	<mat-toolbar 
 		*ngSwitchCase="'complete'"
 		color="primary"
@@ -123,6 +125,19 @@
 				[showContent]=true
 			>
 			</app-skeleton-wide-card>
+		</div>
+	</div>
+	<div 
+		*ngSwitchCase="'serverError'"
+		class="container"
+		fxLayout="column"
+		fxLayoutAlign="center center"
+		>
+		<div
+		fxFlex.gt-sm="690px"
+			fxFlex.gt-md="800px">
+			<app-error-card >
+			</app-error-card>
 		</div>
 	</div>
 	<div 

--- a/src/app/suggestion/view/suggestion-view.component.html
+++ b/src/app/suggestion/view/suggestion-view.component.html
@@ -1,30 +1,18 @@
 <app-loader [isLoading]="isLoading"
     size="1.5"></app-loader>
 
-
-<ng-container *ngIf="isLoading;
-	then skeletonHeader;
-	else mainHeader">
-</ng-container>
-
-<ng-container *ngIf="isLoading;
-	then skeletonSuggestion;
-	else mainSuggestion">
-</ng-container>
-
-<ng-template #skeletonHeader>
-	<!-- <app-skeleton-header [noLogo]=true >
-	</app-skeleton-header> -->
-	<app-skeleton-panel [hasVote]=true>
+<ng-container [ngSwitch]="loadingState">
+	<app-skeleton-panel *ngSwitchCase="'loading'" [hasVote]=true>
 	</app-skeleton-panel>
-</ng-template>
-
-<ng-template #mainHeader>
-	<mat-toolbar color="primary"
+	<mat-toolbar 
+		*ngSwitchCase="'complete'"
+		color="primary"
 		[@fadeIn]="!isLoading"
 		class="header-info-panel"
-		*ngIf="suggestion">
-		<div class="image-container"
+		>
+		<div 
+			*ngIf="suggestion"
+			class="image-container"
 			fxLayout="column"
 			[style.background-image]="'url(' + suggestion.imageUrl + ')'">
 			<div class="admin-panel"
@@ -106,8 +94,8 @@
 				fxFlex.gt-md="800px">
 				<div class="mat-display-1"
 					translate>{{suggestion.title}}</div>
-
-				<app-more-less [displayText]="suggestion.description"
+				<app-more-less 
+					[displayText]="suggestion.description"
 					maxHeight="200">
 				</app-more-less>
 				<mat-divider></mat-divider>
@@ -120,10 +108,12 @@
 			</div>
 		</div>
 	</mat-toolbar>
-</ng-template>
+</ng-container> 
 
-<ng-template #skeletonSuggestion>
-	<div class="container"
+<ng-container [ngSwitch]="loadingState">
+	<div 
+		*ngSwitchCase="'loading'"
+		class="container"
 		fxLayout="column"
 		fxLayoutAlign="center start"
 		>
@@ -135,26 +125,16 @@
 			</app-skeleton-wide-card>
 		</div>
 	</div>
-</ng-template>
-
-<ng-template #mainSuggestion>
-	<div class="container"
-		[@fadeIn]="!isLoading"
-		*ngIf="suggestion"
+	<div 
+		*ngSwitchCase="'complete'"
+		class="container"
+		[@fadeIn]=true
 		fxLayout="row wrap"
 		fxLayoutAlign="center start">
-		<div fxFlex.gt-sm="690px"
+		<div 
+			*ngIf="suggestion"
+			fxFlex.gt-sm="690px"
 			fxFlex.gt-md="800px">
-			<!-- <mat-card class='info-card' *ngIf="suggestion.statements">
-				<mat-card-header>
-					<mat-card-title>Starting Statements</mat-card-title>
-				</mat-card-header>
-				<mat-card-content>
-					<p [innerHtml]="suggestion.statements">
-					</p>
-				</mat-card-content>
-			</mat-card> -->
-
 			<mat-card class='info-card'  *ngIf="suggestion.media.length > 0">
 				<mat-card-header>
 					<mat-card-title>Related Media</mat-card-title>
@@ -166,4 +146,4 @@
 			</mat-card>
 		</div>
 	</div>
-</ng-template>
+</ng-container>

--- a/src/app/suggestion/view/suggestion-view.component.ts
+++ b/src/app/suggestion/view/suggestion-view.component.ts
@@ -13,6 +13,8 @@ import { ISuggestion, Suggestion } from '@app/core/models/suggestion.model';
 import { Vote } from '@app/core/models/vote.model';
 import { trigger } from '@angular/animations';
 import { fadeIn } from '@app/shared/animations/fade-animations';
+import { StateService } from '@app/core/http/state/state.service';
+import { AppState } from '@app/core/models/state.model';
 
 @Component({
 	selector: 'app-suggestion',
@@ -27,8 +29,10 @@ export class SuggestionViewComponent implements OnInit {
 	suggestion: Suggestion;
 	suggestions: Array<Suggestion>;
 	isLoading: boolean;
+	loadingState: string;
 
 	constructor(
+		private stateService: StateService,
 		private suggestionService: SuggestionService,
 		private voteService: VoteService,
 		public auth: AuthenticationService,
@@ -40,7 +44,10 @@ export class SuggestionViewComponent implements OnInit {
 	) { }
 
 	ngOnInit() {
-		this.isLoading = true;
+		this.stateService.loadingState$.subscribe((state: string) => {
+			this.loadingState = state;
+		});
+
 		this.route.paramMap.subscribe(params => {
 			const ID = params.get('id');
 			this.getSuggestion(ID);
@@ -49,16 +56,21 @@ export class SuggestionViewComponent implements OnInit {
 
 	getSuggestion(id: string, forceUpdate?: boolean) {
 		this.suggestionService.view({ id: id, forceUpdate })
-			.pipe(finalize(() => { this.isLoading = false; }))
-			.subscribe((suggestion: Suggestion) => {
-				this.suggestion = suggestion;
-				this.meta.updateTags(
-					{
-						title: `${this.suggestion.title}`,
-						appBarTitle: 'View Suggestion',
-						description: this.suggestion.description
-					});
-			});
+			.subscribe(
+				(suggestion: Suggestion) => {
+					this.suggestion = suggestion;
+					this.meta.updateTags(
+						{
+							title: `${this.suggestion.title}`,
+							appBarTitle: 'View Suggestion',
+							description: this.suggestion.description
+						});
+					return this.stateService.setLoadingState(AppState.complete);
+				},
+				(err) => {
+					this.stateService.setLoadingState(AppState.serverError);
+				}
+			);
 	}
 
 	approveSuggestion() {
@@ -80,14 +92,15 @@ export class SuggestionViewComponent implements OnInit {
 		this.isLoading = true;
 		this.suggestionService.update({ id: this.suggestion._id, entity: this.suggestion })
 			.pipe(finalize(() => { this.isLoading = false; }))
-			.subscribe((t) => {
-				if (t.error) {
-					this.openSnackBar(`Something went wrong: ${t.error.status} - ${t.error.statusText}`, 'OK');
-				} else {
+			.subscribe(
+				(t) => {
 					this.openSnackBar('Succesfully updated', 'OK');
 					this.suggestion = t;
+				},
+				(error) => {
+					this.openSnackBar(`Something went wrong: ${error.status} - ${error.statusText}`, 'OK');
 				}
-			});
+		);
 	}
 
 	onVote(voteData: any) {
@@ -100,18 +113,20 @@ export class SuggestionViewComponent implements OnInit {
 			vote.voteValue = existingVote.voteValue === voteValue ? 0 : voteValue;
 		}
 
-		this.voteService.create({ entity: vote }).subscribe((res) => {
-			if (res.error) {
-				if (res.error.status === 401) {
-					this.openSnackBar('You must be logged in to vote', 'OK');
-				} else {
-					this.openSnackBar('There was an error recording your vote', 'OK');
-				}
-			} else {
-				this.openSnackBar('Your vote was recorded', 'OK');
-				this.getSuggestion(this.suggestion._id, true);
-			}
-		});
+		this.voteService.create({ entity: vote })
+			.subscribe(
+				(res) => {
+						this.openSnackBar('Your vote was recorded', 'OK');
+						this.getSuggestion(this.suggestion._id, true);
+				},
+				(error) => {
+					if (error.status === 401) {
+						this.openSnackBar('You must be logged in to vote', 'OK');
+					} else {
+						this.openSnackBar('There was an error recording your vote', 'OK');
+					}
+				},
+			);
 	}
 
 	onDelete() {
@@ -145,10 +160,11 @@ export class SuggestionViewComponent implements OnInit {
 		dialogRef.afterClosed().subscribe((confirm: boolean) => {
 			if (confirm) {
 				this.suggestion.softDeleted = true;
-				this.suggestionService.update({ id: this.suggestion._id, entity: this.suggestion }).subscribe(() => {
-					this.openSnackBar('Succesfully removed', 'OK');
-					this.router.navigate(['/suggestions'], { queryParams: { forceUpdate: true } });
-				});
+				this.suggestionService.update({ id: this.suggestion._id, entity: this.suggestion })
+					.subscribe(() => {
+						this.openSnackBar('Succesfully removed', 'OK');
+						this.router.navigate(['/suggestions'], { queryParams: { forceUpdate: true } });
+					});
 			}
 		});
 	}
@@ -165,10 +181,11 @@ export class SuggestionViewComponent implements OnInit {
 		dialogRef.afterClosed().subscribe((confirm: boolean) => {
 			if (confirm) {
 				this.suggestion.softDeleted = false;
-				this.suggestionService.update({ id: this.suggestion._id, entity: this.suggestion }).subscribe(() => {
-					this.openSnackBar('Succesfully restored', 'OK');
-					this.router.navigate(['/suggestions'], { queryParams: { forceUpdate: true } });
-				});
+				this.suggestionService.update({ id: this.suggestion._id, entity: this.suggestion })
+					.subscribe(() => {
+						this.openSnackBar('Succesfully restored', 'OK');
+						this.router.navigate(['/suggestions'], { queryParams: { forceUpdate: true } });
+					});
 			}
 		});
 	}


### PR DESCRIPTION
Need feedback on what else to implement / case's I might have missed.

So the approach I took was to move the error handling from the services, where `catchError(e => of([error: e]))` was being called and replaced the observable with a `throwError(e)` so that the error could be handled at the observable subscription. 

The loading state of each component is now managed by a service, so instead of `isLoading` being updated when the app initializes and finishes the API call, components now make calls to a service `StateService` which keeps track of whether the app is in a `loading || serverError || complete` state.  Although all of those states occupy one variable, I think with more "redux" style apps they have multiple states that the app keeps track of. 

Also removed `finalize()` calls on each of the subscriptions. Turns out finalize would run regardless of whether the Observer had an error or resolved + would run after everything on the subscription. So it made updating the loading state difficult.

When it comes to the view, the HTML makes use of `<ng-container>` and `[ngSwitch]` so most components now can handle the various loading states. But the HTML might be looking a bit of a mess, since templates.

Stole the newvote logo and centered it with a bit of text for instances where there are no suggestions/solutions/issues. The all issues page shows `no Topics` instead of `no Issues` since it was easier to check for topics. 

One thing I found though is that it's possible to make an issue without a topic, but the issue will not appear in the All issues page but will appear in what's hot on the front page. Do we want to stop issues being created without topics?

