### PR TITLE
Admin login

### DIFF
--- a/src/app/auth/login/login.component.html
+++ b/src/app/auth/login/login.component.html
@@ -13,7 +13,9 @@
 		 fxFlex.md="50%"
 		 fxFlex.gt-md="33%"
 		 class="login-box">
-			<div *ngIf="this.org.authType && this.org.authType!==0" fxFlex>
+			<div *ngIf="this.org.authType && this.org.authType!==0" 
+				fxFlex
+				fxLayout="column">
 				<button mat-raised-button
 				fxFlex
 				 color="primary"
@@ -21,6 +23,7 @@
 				 (click)="redirect()">
 					<span translate>Login with SSO</span>
 				</button>
+				<a class="signup-terms" href="https://newvote.org/privacy-policy">Terms & Conditions</a>
 			</div>
 			<form *ngIf="!this.org.authType || this.org.authType===0"
 			 (ngSubmit)="login()"

--- a/src/app/auth/login/login.component.html
+++ b/src/app/auth/login/login.component.html
@@ -20,7 +20,7 @@
 				fxFlex
 				 color="primary"
 				 type="button"
-				 (click)="redirect()">
+				 (click)="loginWithSSO()">
 					<span translate>Login with SSO</span>
 				</button>
 				<a class="signup-terms" href="https://newvote.org/privacy-policy">Terms & Conditions</a>

--- a/src/app/auth/login/login.component.scss
+++ b/src/app/auth/login/login.component.scss
@@ -28,3 +28,8 @@
 .login-error {
   color: mat-color($app-warn);
 }
+
+.signup-terms {
+  margin-top: 0.5rem;
+  margin-bottom: 0;
+}

--- a/src/app/auth/login/login.component.ts
+++ b/src/app/auth/login/login.component.ts
@@ -23,6 +23,7 @@ export class LoginComponent implements OnInit {
 	loginForm: FormGroup;
 	isLoading = false;
 	org: Organization;
+	adminLogin: boolean;
 
 	constructor(private router: Router,
 		private route: ActivatedRoute,
@@ -45,6 +46,8 @@ export class LoginComponent implements OnInit {
 				title: `Sign in`,
 				description: 'Fill in your account information to sign in.'
 			});
+
+		this.adminLogin = this.route.snapshot.queryParamMap.get('admin') ? true : false;
 	}
 
 	login() {
@@ -87,6 +90,8 @@ export class LoginComponent implements OnInit {
 	}
 
 	redirect() {
+		const url = this.adminLogin ? this.org.authUrl : this.org.authUrl + this.org.authEntityId;
+
 		debugger;
 		this.cookieService.set('org', this.org.url, null, '/', '.newvote.org');
 		// window.location.href = this.org.authUrl;

--- a/src/app/auth/login/login.component.ts
+++ b/src/app/auth/login/login.component.ts
@@ -90,9 +90,15 @@ export class LoginComponent implements OnInit {
 	}
 
 	redirect() {
-		const url = this.adminLogin ? this.org.authUrl : this.org.authUrl + this.org.authEntityId;
+		let url;
 
-		debugger;
+		if (this.org.authEntityId) {
+			url = this.adminLogin ? this.org.authUrl : this.org.authUrl + this.org.authEntityId;
+		} else {
+			url = this.org.authUrl;
+		}
+
+		// debugger;
 		this.cookieService.set('org', this.org.url, null, '/', '.newvote.org');
 		// window.location.href = this.org.authUrl;
 		console.log('cordova: ', window['cordova']);

--- a/src/app/auth/login/login.component.ts
+++ b/src/app/auth/login/login.component.ts
@@ -91,24 +91,22 @@ export class LoginComponent implements OnInit {
 
 	redirect() {
 		let url;
+		this.cookieService.set('org', this.org.url, null, '/', '.newvote.org');
+		console.log('cordova: ', window['cordova']);
 
 		if (this.org.authEntityId) {
-			url = this.adminLogin ? this.org.authUrl : this.org.authUrl + this.org.authEntityId;
+			url = this.adminLogin ? `${this.org.authUrl}` : `${this.org.authUrl}?entityID=${this.org.authEntityId}`;
 		} else {
-			url = this.org.authUrl;
+			url = `${this.org.authUrl}`;
 		}
 
-		// debugger;
-		this.cookieService.set('org', this.org.url, null, '/', '.newvote.org');
-		// window.location.href = this.org.authUrl;
-		console.log('cordova: ', window['cordova']);
 		if (window['cordova']) {
 			console.log('found cordova opening with inappbrowser');
 			const CORDOVA = window['cordova'];
-			CORDOVA.InAppBrowser.open(this.org.authUrl, '_blank');
-		} else {
-			window.open(this.org.authUrl, '_self');
+			return CORDOVA.InAppBrowser.open(url, '_blank');
 		}
+		
+		return window.open(url, '_self');
 	}
 
 	private createForm() {

--- a/src/app/auth/login/login.component.ts
+++ b/src/app/auth/login/login.component.ts
@@ -89,10 +89,8 @@ export class LoginComponent implements OnInit {
 		return this.i18nService.supportedLanguages;
 	}
 
-	redirect() {
+	loginWithSSO() {
 		let url;
-		this.cookieService.set('org', this.org.url, null, '/', '.newvote.org');
-		console.log('cordova: ', window['cordova']);
 
 		if (this.org.authEntityId) {
 			url = this.adminLogin ? `${this.org.authUrl}` : `${this.org.authUrl}?entityID=${this.org.authEntityId}`;
@@ -100,12 +98,6 @@ export class LoginComponent implements OnInit {
 			url = `${this.org.authUrl}`;
 		}
 
-		if (window['cordova']) {
-			console.log('found cordova opening with inappbrowser');
-			const CORDOVA = window['cordova'];
-			return CORDOVA.InAppBrowser.open(url, '_blank');
-		}
-		
 		return window.open(url, '_self');
 	}
 

--- a/src/app/core/models/organization.model.ts
+++ b/src/app/core/models/organization.model.ts
@@ -16,6 +16,7 @@ export interface IOrganization {
 	softDeleted: boolean;
 	authType: Number;
 	authUrl: string;
+	authEntityId: string;
 	privateOrg: boolean;
 }
 
@@ -37,6 +38,7 @@ export class Organization implements IOrganization {
 		public softDeleted: boolean = false,
 		public authType: Number = 0,
 		public authUrl: string = '',
+		public authEntityId: string = '',
 		public privateOrg: boolean = false
 	) { }
 }

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -155,7 +155,7 @@
 				<button *ngIf="this.org && this.org.authType===1"
 				 mat-button
 				 mat-raised-button
-				 (click)="redirect()"
+				 routerLink="/auth/login"
 				 color="warn"
 				 class="mat-display-1">
 					CREATE ACCOUNT</button>
@@ -311,7 +311,7 @@
 			<button *ngIf="this.org && this.org.authType===1"
 			 mat-button
 			 mat-raised-button
-			 (click)="redirect()"
+			 routerLink="/auth/login"
 			 color="warn"
 			 class="mat-display-1">
 				CREATE ACCOUNT</button>

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -19,6 +19,7 @@ import { fadeIn } from '@app/shared/animations/fade-animations';
 import { forkJoin } from 'rxjs';
 import { StateService } from '@app/core/http/state/state.service';
 import { AppState } from '@app/core/models/state.model';
+import { Router } from '@angular/router';
 
 @Component({
 	selector: 'app-home',
@@ -50,7 +51,8 @@ export class HomeComponent implements OnInit {
 		private proposalService: ProposalService,
 		private userService: UserService,
 		private meta: MetaService,
-		private cookieService: CookieService
+		private cookieService: CookieService,
+		private router: Router
 	) { }
 
 	ngOnInit() {
@@ -132,7 +134,7 @@ export class HomeComponent implements OnInit {
 	redirect() {
 		this.cookieService.set('org', this.org.url, null, '/', '.newvote.org');
 		// window.location.href = this.org.authUrl;
-		window.open(this.org.authUrl, '_self');
+		this.router.navigate(['/auth/login'])
 	}
 
 	handleUserCount(count: number) {

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -131,12 +131,6 @@ export class HomeComponent implements OnInit {
 		});
 	}
 
-	redirect() {
-		this.cookieService.set('org', this.org.url, null, '/', '.newvote.org');
-		// window.location.href = this.org.authUrl;
-		this.router.navigate(['/auth/login'])
-	}
-
 	handleUserCount(count: number) {
 		if (!count) {
 			return `0`;

--- a/src/app/organization/create/organization-create.component.html
+++ b/src/app/organization/create/organization-create.component.html
@@ -75,6 +75,14 @@
 				 required>
 			</mat-form-field>
 
+			<mat-form-field *ngIf="auth.isAdmin() && this.organizationForm.value.authType!==0">
+				<input matInput
+				 type="text"
+				 placeholder="Enter the Entity ID for AAF authentication"
+				 formControlName="authEntityId"
+				 required>
+			</mat-form-field>
+
 			<mat-form-field>
 				<mat-label>Public / Private Organization</mat-label>
 				<mat-select formControlName="privateOrg" 

--- a/src/app/organization/create/organization-create.component.ts
+++ b/src/app/organization/create/organization-create.component.ts
@@ -45,6 +45,7 @@ export class OrganizationCreateComponent implements OnInit {
 		moderatorsControl: new FormControl([], [Validators.email]),
 		authType: new FormControl(0, [Validators.required]),
 		authUrl: new FormControl('', [Validators.required]),
+		authEntityId: new FormControl('', [Validators.required]),
 		privateOrg: new FormControl(false, [Validators.required])
 	});
 

--- a/src/app/organization/create/organization-create.component.ts
+++ b/src/app/organization/create/organization-create.component.ts
@@ -101,6 +101,30 @@ export class OrganizationCreateComponent implements OnInit {
 				title: 'Create Community',
 				description: 'Create a new community on the NewVote platform.'
 			});
+
+		this.setAuthtypeValidators();
+	}
+
+	setAuthtypeValidators() {
+		const authUrl = this.organizationForm.get('authUrl');
+		const authEntityId = this.organizationForm.get('authEntityId');
+
+		this.organizationForm.get('authType').valueChanges
+			.subscribe((authType) => {
+
+				if (authType === 0) {
+					authUrl.setValidators(null);
+					authEntityId.setValidators(null);
+				}
+
+				if (authType === 1) {
+					authUrl.setValidators([Validators.required]);
+					authEntityId.setValidators([Validators.required]);
+				}
+
+				authUrl.updateValueAndValidity();
+				authEntityId.updateValueAndValidity();
+			});
 	}
 
 	buildItemForm() {

--- a/src/app/organization/edit/organization-edit.component.html
+++ b/src/app/organization/edit/organization-edit.component.html
@@ -82,6 +82,14 @@
 				 required>
 			</mat-form-field>
 
+			<mat-form-field *ngIf="auth.isAdmin() && this.organizationForm.value.authType!==0">
+				<input matInput
+				 type="text"
+				 placeholder="Enter the Entity ID for AAF authentication"
+				 formControlName="authEntityId"
+				 required>
+			</mat-form-field>
+			
 			<mat-form-field>
 				<mat-label>Public / Private Organization</mat-label>
 				<mat-select formControlName="privateOrg" [value]="false"

--- a/src/app/organization/edit/organization-edit.component.ts
+++ b/src/app/organization/edit/organization-edit.component.ts
@@ -130,6 +130,7 @@ export class OrganizationEditComponent implements OnInit {
 						'newLeaderEmail': '',
 						'authType': organization.authType,
 						'authUrl': organization.authUrl,
+						'authEntityId': organization.authEntityId || '',
 						'privateOrg': organization.privateOrg || false
 					});
 

--- a/src/app/organization/edit/organization-edit.component.ts
+++ b/src/app/organization/edit/organization-edit.component.ts
@@ -48,6 +48,7 @@ export class OrganizationEditComponent implements OnInit {
 		moderatorsControl: new FormControl([], [Validators.email]),
 		authType: new FormControl(0, [Validators.required]),
 		authUrl: new FormControl('', [Validators.required]),
+		authEntityId: new FormControl('', [Validators.required]),
 		privateOrg: new FormControl(false, [Validators.required])
 	});
 
@@ -130,7 +131,7 @@ export class OrganizationEditComponent implements OnInit {
 						'newLeaderEmail': '',
 						'authType': organization.authType,
 						'authUrl': organization.authUrl,
-						'authEntityId': organization.authEntityId || '',
+						'authEntityId': organization.authEntityId,
 						'privateOrg': organization.privateOrg || false
 					});
 
@@ -149,6 +150,30 @@ export class OrganizationEditComponent implements OnInit {
 		if (this.auth.isAdmin()) {
 			this.userService.list({}).subscribe(users => this.allUsers = users);
 		}
+
+		this.setAuthtypeValidators();
+	}
+
+	setAuthtypeValidators() {
+		const authUrl = this.organizationForm.get('authUrl');
+		const authEntityId = this.organizationForm.get('authEntityId');
+
+		this.organizationForm.get('authType').valueChanges
+			.subscribe((authType) => {
+
+				if (authType === 0) {
+					authUrl.setValidators(null);
+					authEntityId.setValidators(null);
+				}
+
+				if (authType === 1) {
+					authUrl.setValidators([Validators.required]);
+					authEntityId.setValidators([Validators.required]);
+				}
+
+				authUrl.updateValueAndValidity();
+				authEntityId.updateValueAndValidity();
+			});
 	}
 
 	buildItemForm() {

--- a/src/app/shell/shell.component.html
+++ b/src/app/shell/shell.component.html
@@ -123,11 +123,11 @@
 					</mat-list>
 					<mat-list *ngIf="this.organization && this.organization.authType === 1">
 						<a mat-menu-item
-						 (click)="redirect()"
+						 routerLink="/auth/login"
 						 translate>Login</a>
 						<mat-divider></mat-divider>
 						<a mat-menu-item
-						 (click)="redirect()"
+						 routerLink="/auth/login"
 						 translate>Create Account</a>
 					</mat-list>
 				</mat-menu>
@@ -167,10 +167,10 @@
 				 class="hide-login-menu">
 					<button mat-stroked-button
 					 class="border-override"
-					 (click)="redirect()">Sign In</button>
+					 routerLink="/auth/login">Sign In</button>
 					<button mat-flat-button
 					 color="warn"
-					 (click)="redirect()">Create Account</button>
+					 routerLink="/auth/login">Create Account</button>
 				</div>
 			</mat-toolbar>
 			<!-- only show if search button pressed -->

--- a/src/app/shell/shell.component.ts
+++ b/src/app/shell/shell.component.ts
@@ -108,6 +108,14 @@ export class ShellComponent implements OnInit {
 	redirect() {
 		this.cookieService.set('org', this.organization.url, null, '/', '.newvote.org');
 		// window.location.href = this.org.authUrl;
+		if (this.auth.isAdmin() && this.organization.authEntityId) {
+			return window.open(this.organization.authUrl, '_self');
+		}
+
+		if (this.organization.authEntityId) {
+			window.open(this.organization.authUrl + this.organization.authEntityId, '_self');
+		}
+
 		window.open(this.organization.authUrl, '_self');
 	}
 

--- a/src/app/shell/shell.component.ts
+++ b/src/app/shell/shell.component.ts
@@ -105,16 +105,6 @@ export class ShellComponent implements OnInit {
 		return link;
 	}
 
-	redirect() {
-		this.cookieService.set('org', this.organization.url, null, '/', '.newvote.org');
-		// window.location.href = this.org.authUrl;
-		if (this.auth.isAdmin()) {
-			return this.router.navigate(['/auth/login?admin="true']);
-		}
-
-		return this.router.navigate(['/auth/login']);
-	}
-
 	redirectToLanding() {
 		const { hostname } = window.location;
 

--- a/src/app/shell/shell.component.ts
+++ b/src/app/shell/shell.component.ts
@@ -108,15 +108,11 @@ export class ShellComponent implements OnInit {
 	redirect() {
 		this.cookieService.set('org', this.organization.url, null, '/', '.newvote.org');
 		// window.location.href = this.org.authUrl;
-		if (this.auth.isAdmin() && this.organization.authEntityId) {
-			return window.open(this.organization.authUrl, '_self');
+		if (this.auth.isAdmin()) {
+			return this.router.navigate(['/auth/login?admin="true']);
 		}
 
-		if (this.organization.authEntityId) {
-			window.open(this.organization.authUrl + this.organization.authEntityId, '_self');
-		}
-
-		window.open(this.organization.authUrl, '_self');
+		return this.router.navigate(['/auth/login']);
 	}
 
 	redirectToLanding() {


### PR DESCRIPTION
- Changed redirect on Home / shell components to redirect users to the login page again.
- Login page now has terms and conditions link
- Community edit/create has new field `authEntityId` for the AAF login
- Organization create/edit now has conditional validators (fixes issue where local signup authType could not update without SSO authUrl field being filled in)
- login page handles `?admin` query parameter to handle admin logins. 