### PR TITLE
Scroll fix

### DIFF
--- a/src/app/shell/shell.component.ts
+++ b/src/app/shell/shell.component.ts
@@ -12,6 +12,7 @@ import { asyncScheduler } from 'rxjs';
 import { filter, observeOn } from 'rxjs/operators';
 import { CdkScrollable, ScrollDispatcher } from '@angular/cdk/overlay';
 import { ScrollService } from '@app/core/scroll/scroll.service';
+import { I18nService } from '@app/core';
 
 
 interface ScrollPositionRestore {


### PR DESCRIPTION
Taken from - https://blog.angularindepth.com/reactive-scroll-position-restoration-with-rxjs-792577f842c

Moved the scroll restore to `NavigationEnd` but delayed when `NavigationEnd` event fires in the component lifecycle so scroll position is restored.