### PR TITLE
Site redirects

### DIFF
--- a/src/app/issue/create/issue-create.component.ts
+++ b/src/app/issue/create/issue-create.component.ts
@@ -158,7 +158,7 @@ export class IssueCreateComponent implements OnInit {
 						}
 
 						this.openSnackBar('Succesfully created', 'OK');
-						this.router.navigate(['/issues'], { queryParams: { forceUpdate: true } });
+						this.router.navigate([`/issues/${t._id}`], { queryParams: { forceUpdate: true } });
 					},
 					(err) => {
 						this.openSnackBar(`Something went wrong: ${err.status} - ${err.statusText}`, 'OK');

--- a/src/app/issue/edit/issue-edit.component.ts
+++ b/src/app/issue/edit/issue-edit.component.ts
@@ -179,7 +179,7 @@ export class IssueEditComponent implements OnInit {
 					this.openSnackBar(`Something went wrong: ${t.error.status} - ${t.error.statusText}`, 'OK');
 				} else {
 					this.openSnackBar('Succesfully updated', 'OK');
-					this.router.navigate(['/issues'], { queryParams: { forceUpdate: true } });
+					this.router.navigate([`/issues/${t._id}`], { queryParams: { forceUpdate: true } });
 				}
 			});
 	}

--- a/src/app/issue/list/issue-list.component.ts
+++ b/src/app/issue/list/issue-list.component.ts
@@ -278,6 +278,7 @@ export class IssueListComponent implements OnInit {
 		this.suggestionService.create({ entity: suggestion })
 			.subscribe(t => {
 				this.openSnackBar('Succesfully created', 'OK');
+				this.router.navigate([`/suggestions/${t._id}`], { replaceUrl: true });
 			},
 			(error) => {
 				this.openSnackBar(`Something went wrong: ${error.status} - ${error.statusText}`, 'OK');

--- a/src/app/issue/view/issue-view.component.ts
+++ b/src/app/issue/view/issue-view.component.ts
@@ -343,6 +343,7 @@ export class IssueViewComponent implements OnInit {
 		this.suggestionService.create({ entity: suggestion })
 			.subscribe(t => {
 				this.openSnackBar('Succesfully created', 'OK');
+				this.router.navigate([`/suggestions/${t._id}`], { replaceUrl: true });
 			},
 			(error) => {
 				this.openSnackBar(`Something went wrong: ${error.status} - ${error.statusText}`, 'OK');

--- a/src/app/proposal/create/proposal-create.component.ts
+++ b/src/app/proposal/create/proposal-create.component.ts
@@ -180,7 +180,7 @@ export class ProposalCreateComponent implements OnInit {
 						}
 
 						this.openSnackBar('Succesfully created', 'OK');
-						this.router.navigate([`/solutions/${this.proposal.solutions[0]._id}`], { queryParams: { forceUpdate: true } });
+						this.router.navigate([`/proposals/${t._id}`], { queryParams: { forceUpdate: true } });
 					},
 					(error) => this.openSnackBar(`Something went wrong: ${error.status} - ${error.statusText}`, 'OK')
 

--- a/src/app/proposal/edit/proposal-edit.component.ts
+++ b/src/app/proposal/edit/proposal-edit.component.ts
@@ -178,7 +178,7 @@ export class ProposalEditComponent implements OnInit {
 					this.openSnackBar(`Something went wrong: ${t.error.status} - ${t.error.statusText}`, 'OK');
 				} else {
 					this.openSnackBar('Succesfully updated', 'OK');
-					this.router.navigate(['/proposals']);
+					this.router.navigate([`/proposals/${t._id}`]);
 				}
 			});
 	}

--- a/src/app/proposal/view/proposal-view.component.ts
+++ b/src/app/proposal/view/proposal-view.component.ts
@@ -229,6 +229,7 @@ export class ProposalViewComponent implements OnInit {
 		this.suggestionService.create({ entity: suggestion })
 			.subscribe(t => {
 				this.openSnackBar('Succesfully created', 'OK');
+				this.router.navigate([`/suggestions/${t._id}`], { replaceUrl: true });
 			},
 			(error) => {
 				this.openSnackBar(`Something went wrong: ${error.status} - ${error.statusText}`, 'OK');

--- a/src/app/solution/create/solution-create.component.ts
+++ b/src/app/solution/create/solution-create.component.ts
@@ -198,9 +198,7 @@ export class SolutionCreateComponent implements OnInit {
 							this.openSnackBar('Succesfully created', 'OK');
 							this.router.navigate([`/solutions/${t._id}`], {queryParams: {forceUpdate: true} });
 						},
-						(err) => {
-							console.log(err, 'this is err');
-							this.openSnackBar(`Something went wrong: ${err.status} - ${err.statusText}`, 'OK'})
+						(err) => this.openSnackBar(`Something went wrong: ${err.status} - ${err.statusText}`, 'OK')
 					);
 			}
 		};

--- a/src/app/solution/create/solution-create.component.ts
+++ b/src/app/solution/create/solution-create.component.ts
@@ -182,7 +182,7 @@ export class SolutionCreateComponent implements OnInit {
 						this.openSnackBar(`Something went wrong: ${t.error.status} - ${t.error.statusText}`, 'OK');
 					} else {
 						this.openSnackBar('Succesfully created', 'OK');
-						this.router.navigate(['/solutions'], {queryParams: {forceUpdate: true} });
+						this.router.navigate([`/solutions/${t._id}`], { queryParams: { forceUpdate: true } });
 					}
 			});
 		}
@@ -195,13 +195,13 @@ export class SolutionCreateComponent implements OnInit {
 				this.solutionService.create({ entity: this.solution })
 					.pipe(finalize(() => { this.isLoading = false; }))
 					.subscribe(t => {
-						if (t.error) {
-							this.openSnackBar(`Something went wrong: ${t.error.status} - ${t.error.statusText}`, 'OK');
-						} else {
 							this.openSnackBar('Succesfully created', 'OK');
-							this.router.navigate(['/solutions'], {queryParams: {forceUpdate: true} });
-						}
-					});
+							this.router.navigate([`/solutions/${t._id}`], {queryParams: {forceUpdate: true} });
+						},
+						(err) => {
+							console.log(err, 'this is err');
+							this.openSnackBar(`Something went wrong: ${err.status} - ${err.statusText}`, 'OK'})
+					);
 			}
 		};
 

--- a/src/app/solution/edit/solution-edit.component.ts
+++ b/src/app/solution/edit/solution-edit.component.ts
@@ -179,7 +179,7 @@ export class SolutionEditComponent implements OnInit {
 					this.openSnackBar(`Something went wrong: ${t.error.status} - ${t.error.statusText}`, 'OK');
 				} else {
 					this.openSnackBar('Succesfully updated', 'OK');
-					this.router.navigate(['/solutions']);
+					this.router.navigate([`/solutions/${t._id}`], { queryParams: { forceUpdate: true } });
 				}
 			});
 	}

--- a/src/app/solution/list/solution-list.component.ts
+++ b/src/app/solution/list/solution-list.component.ts
@@ -238,6 +238,7 @@ export class SolutionListComponent implements OnInit {
 		this.suggestionService.create({ entity: suggestion })
 			.subscribe(t => {
 				this.openSnackBar('Succesfully created', 'OK');
+				this.router.navigate([`/suggestions/${t._id}`], { replaceUrl: true });
 			},
 			(error) => {
 				this.openSnackBar(`Something went wrong: ${error.status} - ${error.statusText}`, 'OK');

--- a/src/app/solution/view/solution-view.component.ts
+++ b/src/app/solution/view/solution-view.component.ts
@@ -267,6 +267,7 @@ export class SolutionViewComponent implements OnInit {
 		this.suggestionService.create({ entity: suggestion })
 			.subscribe(t => {
 				this.openSnackBar('Succesfully created', 'OK');
+				this.router.navigate([`/suggestions/${t._id}`], { replaceUrl: true });
 			},
 			(error) => {
 				this.openSnackBar(`Something went wrong: ${error.status} - ${error.statusText}`, 'OK');

--- a/src/app/suggestion/create/suggestion-create.component.ts
+++ b/src/app/suggestion/create/suggestion-create.component.ts
@@ -48,6 +48,7 @@ export class SuggestionCreateComponent implements OnInit {
 	@ViewChild('parentInput') parentInput: ElementRef<HTMLInputElement>;
 	@ViewChild('mediaInput') mediaInput: ElementRef<HTMLInputElement>;
 	@ViewChild('auto') matAutocomplete: MatAutocomplete;
+	
 
 	constructor(
 		private suggestionService: SuggestionService,
@@ -99,18 +100,25 @@ export class SuggestionCreateComponent implements OnInit {
 			this.suggestionForm.patchValue({type: this.suggestionType});
 		}
 
+		// If a user is making a suggestion from an entity - populate the form with parentData
 		this.route.paramMap
 			.pipe(
-				map(() => window.history.state),
+				map((data) => {
+					return {
+						params: data,
+						state: window.history.state
+					}
+				}),
 				delay(0)
 			)
-			.subscribe((res) => {
-				if (res._id || res.parentTitle || res.type) {
-					if (res._id) {
-						this.suggestionForm.patchValue({parent: res._id});
+			.subscribe((routeData) => {
+				const { params, state } = routeData;
+				if (state._id || state.parentTitle || state.type) {
+					if (state._id) {
+						this.suggestionForm.patchValue({parent: state._id});
 					}
 
-					this.suggestionForm.patchValue(res);
+					this.suggestionForm.patchValue(state);
 					this.suggestionForm.controls['type'].disable();
 				} else {
 					this.suggestionForm.controls['parentTitle'].disable();
@@ -150,9 +158,9 @@ export class SuggestionCreateComponent implements OnInit {
 
 		this.suggestionService.create({ entity: this.suggestion })
 			.pipe(finalize(() => { this.isLoading = false; }))
-			.subscribe(t => {
+			.subscribe((suggestion: Suggestion) => {
 				this.openSnackBar('Succesfully created', 'OK');
-				this.router.navigate([`/suggestions`], { queryParams: { forceUpdate: true } });
+				this.router.navigate([`/suggestions/${suggestion._id}`], { replaceUrl: true, queryParams: { forceUpdate: true } });
 			},
 			(error => {
 				this.openSnackBar(`Something went wrong: ${error.status} - ${error.statusText}`, 'OK');

--- a/src/app/suggestion/edit/suggestion-edit.component.ts
+++ b/src/app/suggestion/edit/suggestion-edit.component.ts
@@ -100,7 +100,7 @@ export class SuggestionEditComponent implements OnInit {
 					this.openSnackBar(`Something went wrong: ${t.error.status} - ${t.error.statusText}`, 'OK');
 				} else {
 					this.openSnackBar('Succesfully updated', 'OK');
-					this.router.navigate([`/suggestions`], { queryParams: { forceUpdate: true } });
+					this.router.navigate([`/suggestions/${t._id}`], { queryParams: { forceUpdate: true } });
 				}
 			});
 	}


### PR DESCRIPTION
Requires backend branch `bug/redirects`

Added redirects to make suggestion component success response.

Redirects in general after creating content, will redirect to the new entity object that was made, instead of the list page.