### PR TITLE
Feature/akita organization

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -75,7 +75,7 @@ import { SocketIoModule, SocketIoConfig } from 'ngx-socket-io';
 		RecaptchaModule,
 		RecaptchaFormsModule,
 		SocketIoModule.forRoot({
-			url: environment.production ? environment.socketUrl : 'http://localhost:3000',
+			url: environment.socketUrl,
 			options: {}
 		}),
 		environment.production ? [] : AkitaNgDevtools.forRoot(),

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -75,7 +75,7 @@ import { SocketIoModule, SocketIoConfig } from 'ngx-socket-io';
 		RecaptchaModule,
 		RecaptchaFormsModule,
 		SocketIoModule.forRoot({
-			url: environment.production ? environment.serverUrl : 'http://localhost:3000',
+			url: environment.production ? environment.socketUrl : 'http://localhost:3000',
 			options: {}
 		}),
 		environment.production ? [] : AkitaNgDevtools.forRoot(),

--- a/src/app/core/http/issue/issue.query.ts
+++ b/src/app/core/http/issue/issue.query.ts
@@ -1,11 +1,51 @@
 import { Injectable } from "@angular/core";
-import { QueryEntity } from "@datorama/akita";
+import { QueryEntity, combineQueries } from "@datorama/akita";
 import { IssueState, IssueStore } from "./issue.store";
 import { Issue } from "@app/core/models/issue.model";
+import { TopicQuery } from "../topic/topic.query";
+import { map } from "rxjs/operators";
+
+import { cloneDeep } from 'lodash';
 
 @Injectable()
 export class IssueQuery extends QueryEntity<IssueState, Issue> {
-    constructor(protected store: IssueStore) {
+    constructor(protected store: IssueStore, private topicQuery: TopicQuery) {
         super(store);
+    }
+
+    getIssueWithTopic(issueId: string) {
+        return combineQueries(
+            [
+                this.selectEntity(issueId),
+                this.topicQuery.selectAll()
+            ]
+        )
+            .pipe(
+                map((results) => {
+                    let [storeIssue, topics] = results;
+                    const issue = cloneDeep(storeIssue);
+
+                    if (!issue) {
+                        return false;
+                    }
+
+                    if (!topics.length) {
+                        return issue;
+                    }
+
+                    const populateIssueTopics = issue.topics.map((issueTopic) => {
+                        return topics.find((topic) => {
+                            if (typeof issueTopic === 'string') {
+                                return issueTopic === topic._id;
+                            }
+
+                            return topic._id === issueTopic._id;
+                        })
+                    })
+
+                    issue.topics = populateIssueTopics;
+                    return issue;
+                })
+            )
     }
 }

--- a/src/app/core/http/organization/organization.service.ts
+++ b/src/app/core/http/organization/organization.service.ts
@@ -29,7 +29,7 @@ export interface OrganizationContext {
 
 @Injectable()
 export class OrganizationService {
-	
+
 	private _host: string;
 	private _subdomain: string;
 	private _org: Organization;
@@ -54,7 +54,6 @@ export class OrganizationService {
 			this.httpClient
 				.get('/organizations/' + this._subdomain)
 				.pipe(
-					tap((org: Organization) => {this.joinWebSocketRoom(org.url)}),
 					catchError(handleError)
 				).subscribe(
 					(org: Organization) => {
@@ -62,6 +61,7 @@ export class OrganizationService {
 						this.organizationStore.update(org);
 						this._org = org;
 						this.$org.next(org);
+						this.joinWebSocketRoom(org.url)
 					},
 					(err) => {
 						this.$org.next(null);

--- a/src/app/issue/create/issue-create.component.ts
+++ b/src/app/issue/create/issue-create.component.ts
@@ -8,13 +8,14 @@ import { Observable } from 'rxjs';
 import { map, startWith, finalize, delay } from 'rxjs/operators';
 
 import { IIssue } from '@app/core/models/issue.model';
-import { ITopic } from '@app/core/models/topic.model';
+import { ITopic, Topic } from '@app/core/models/topic.model';
 import { IssueService } from '@app/core/http/issue/issue.service';
 import { TopicService } from '@app/core/http/topic/topic.service';
 import { Organization } from '@app/core/models/organization.model';
 import { OrganizationService } from '@app/core/http/organization/organization.service';
 import { MetaService } from '@app/core/meta.service';
 import { SuggestionService } from '@app/core/http/suggestion/suggestion.service';
+import { TopicQuery } from '@app/core/http/topic/topic.query';
 
 @Component({
 	selector: 'app-issue',
@@ -53,7 +54,8 @@ export class IssueCreateComponent implements OnInit {
 		public snackBar: MatSnackBar,
 		private router: Router,
 		private route: ActivatedRoute,
-		private meta: MetaService
+		private meta: MetaService,
+		private topicQuery: TopicQuery
 	) {
 		this.filteredTopics = this.issueForm.get('topics').valueChanges.pipe(
 			startWith(''),
@@ -78,6 +80,8 @@ export class IssueCreateComponent implements OnInit {
 			]
 		};
 
+		this.subscribeToTopicStore();
+
 		this.uploader = new FileUploader(uploaderOptions);
 
 		this.uploader.onBuildItemForm = (fileItem: any, form: FormData): any => {
@@ -92,7 +96,10 @@ export class IssueCreateComponent implements OnInit {
 		};
 
 		this.topicService.list({})
-			.subscribe(topics => this.allTopics = topics);
+			.subscribe(
+				res => res,
+				(err) => err
+			);
 
 		this.organizationService.get().subscribe(org => this.organization = org);
 
@@ -116,6 +123,13 @@ export class IssueCreateComponent implements OnInit {
 					})
 				}
 			});
+	}
+
+	subscribeToTopicStore() {
+		this.topicQuery.selectAll()
+			.subscribe(
+				(topics: Topic[]) => this.allTopics = topics
+			)
 	}
 
 	onFileChange(event: any) {

--- a/src/app/issue/create/issue-create.component.ts
+++ b/src/app/issue/create/issue-create.component.ts
@@ -114,7 +114,7 @@ export class IssueCreateComponent implements OnInit {
 						name: suggestion.title,
 						description: suggestion.description
 					})
-				} 
+				}
 			});
 	}
 
@@ -158,7 +158,7 @@ export class IssueCreateComponent implements OnInit {
 						}
 
 						this.openSnackBar('Succesfully created', 'OK');
-						this.router.navigate([`/issues/${t._id}`], { queryParams: { forceUpdate: true } });
+						this.router.navigate([`/issues/${t._id}`]);
 					},
 					(err) => {
 						this.openSnackBar(`Something went wrong: ${err.status} - ${err.statusText}`, 'OK');

--- a/src/app/issue/edit/issue-edit.component.ts
+++ b/src/app/issue/edit/issue-edit.component.ts
@@ -16,6 +16,8 @@ import { Organization } from '@app/core/models/organization.model';
 import { OrganizationService } from '@app/core/http/organization/organization.service';
 import { MetaService } from '@app/core/meta.service';
 import { IssueQuery } from '@app/core/http/issue/issue.query';
+import { AppState } from '@app/core/models/state.model';
+import { StateService } from '@app/core/http/state/state.service';
 
 @Component({
 	selector: 'app-issue',
@@ -53,7 +55,8 @@ export class IssueEditComponent implements OnInit {
 		public snackBar: MatSnackBar,
 		private router: Router,
 		private meta: MetaService,
-		private issueQuery: IssueQuery
+		private issueQuery: IssueQuery,
+		private stateService: StateService
 	) {
 		this.filteredTopics = this.issueForm.get('topics').valueChanges.pipe(
 			startWith(''),
@@ -193,6 +196,7 @@ export class IssueEditComponent implements OnInit {
 			.pipe(finalize(() => { this.isLoading = false; }))
 			.subscribe(
 				(t) => {
+					this.stateService.setLoadingState(AppState.loading);
 					this.openSnackBar('Succesfully updated', 'OK');
 					this.router.navigate([`/issues/${t._id}`]);
 				},

--- a/src/app/issue/view/issue-view.component.html
+++ b/src/app/issue/view/issue-view.component.html
@@ -1,4 +1,4 @@
-<app-loader  [isLoading]="loadingState === 'loading' || isLoading"
+<app-loader [isLoading]="loadingState === 'loading' || isLoading"
     size="1.5"></app-loader>
 
 
@@ -13,57 +13,53 @@
 </ng-container>
 
 <ng-template #skeletonMedia>
-	<div class="skeleton-media-container">
-		<div class="center-item">
-			<app-skeleton-text-bar class="center-item" [isHeading]=true [width]="150">
-			</app-skeleton-text-bar>
-		</div>
-		<div class="skeleton-media-card-wrap">
-			<app-skeleton-media-card>
-			</app-skeleton-media-card>
-		</div>
-	</div>
+    <div class="skeleton-media-container">
+        <div class="center-item">
+            <app-skeleton-text-bar class="center-item"
+                [isHeading]=true
+                [width]="150">
+            </app-skeleton-text-bar>
+        </div>
+        <div class="skeleton-media-card-wrap">
+            <app-skeleton-media-card>
+            </app-skeleton-media-card>
+        </div>
+    </div>
 </ng-template>
 
 <ng-template #mainMedia>
-	<div 
-		[@fadeIn]=true
-		class="container"
-		*ngIf="media"
-		fxLayout="row wrap"
-		fxLayoutAlign="center center"
-		>
-		<div
-			fxFlex.gt-sm="690px"
-			fxFlex.gt-md="800px"
-			*ngIf="media && !headingEdit"
-			[style.width]="'100%'"
-			>
-			<mat-accordion>
-				<mat-expansion-panel class="accordion-header">
-					<mat-expansion-panel-header>
-						<h3 class="mat-headline" 
-							[ngStyle]="{ 'margin-bottom': '0px', 'text-align': 'center', 'width': '100%'}"
-							>
-							{{ this.issue.mediaHeading || "Third Party Media"}}
-						</h3>
-					</mat-expansion-panel-header>
-						<app-swiper-wrapper 
-							[@fadeIn]=true
-							path="/media"
-							[items]="media"
-							model="Media"
-							parent="Issue"
-							[organization]="issue.organizations.name"
-							(restore)="admin.onRestore($event, 'Media')"
-							(softDelete)="admin.onSoftDelete($event, 'Media')"
-							(delete)="admin.onDelete($event, 'Media')"
-							(vote)="onVote($event, 'Media')">
-						</app-swiper-wrapper>
-		</mat-expansion-panel>
-	</mat-accordion>
-</div>
-</div>
+    <div [@fadeIn]=true
+        class="container"
+        *ngIf="media"
+        fxLayout="row wrap"
+        fxLayoutAlign="center center">
+        <div fxFlex.gt-sm="690px"
+            fxFlex.gt-md="800px"
+            *ngIf="media && !headingEdit"
+            [style.width]="'100%'">
+            <mat-accordion>
+                <mat-expansion-panel class="accordion-header">
+                    <mat-expansion-panel-header>
+                        <h3 class="mat-headline"
+                            [ngStyle]="{ 'margin-bottom': '0px', 'text-align': 'center', 'width': '100%'}">
+                            {{ this.issue.mediaHeading || "Third Party Media"}}
+                        </h3>
+                    </mat-expansion-panel-header>
+                    <app-swiper-wrapper [@fadeIn]=true
+                        path="/media"
+                        [items]="media"
+                        model="Media"
+                        parent="Issue"
+                        [organization]="issue.organizations.name"
+                        (restore)="admin.onRestore($event, 'Media')"
+                        (softDelete)="admin.onSoftDelete($event, 'Media')"
+                        (delete)="admin.onDelete($event, 'Media')"
+                        (vote)="onVote($event, 'Media')">
+                    </app-swiper-wrapper>
+                </mat-expansion-panel>
+            </mat-accordion>
+        </div>
+    </div>
 </ng-template>
 
 
@@ -75,199 +71,200 @@
 <!-- Header Template -->
 
 <ng-template #skeletonHeader>
-	<app-skeleton-header [noLogo]=true >
-	</app-skeleton-header>
-	<app-skeleton-panel [hasChip]=true>
-	</app-skeleton-panel>
+    <app-skeleton-header [noLogo]=true>
+    </app-skeleton-header>
+    <app-skeleton-panel [hasChip]=true>
+    </app-skeleton-panel>
 </ng-template>
 
 <ng-template #mainIssueHeader>
-	<mat-toolbar 
-		[@fadeIn]="!isLoading"
-		color="primary"
-		class="header-info-panel"
-		*ngIf="issue">
-		<div class="image-container"
-			
-			fxLayout="column"
-			[defaultImage]="handleImageUrl(issue.imageUrl, true)"
-			[lazyLoad]="handleImageUrl(issue.imageUrl)">
-			<div class="admin-panel"
-				*ngIf="auth.isModerator(issue)"
-				fxLayout="column"
-				fxLayoutAlign="center end">
-				<div class="button-panel">
-					<button mat-icon-button
-						matTooltip="Create a new Issue"
-						color="accent"
-						routerLink="/issues/create">
-							<mat-icon aria-label="Create a new issue">add</mat-icon>
-					</button>
-					<button mat-icon-button
-						matTooltip="Add Solution for this Issue"
-						color="accent"
-						routerLink="/solutions/create/{{issue._id}}">
-							<mat-icon aria-label="Add a new solution">playlist_add</mat-icon>
-					</button>
-					<button mat-icon-button
-						matTooltip="Add Media to this Issue"
-						color="accent"
-						routerLink="/media/create/{{issue._id}}">
-							<mat-icon aria-label="Add new media">add_a_photo</mat-icon>
-					</button>
-					<button mat-icon-button
-						matTooltip="Edit this Issue"
-						color="accent"
-						routerLink="/issues/edit/{{issue._id}}">
-							<mat-icon aria-label="Edit the issue">edit</mat-icon>
-						</button>
-					<button mat-icon-button
-						*ngIf="issue.softDeleted"
-						matTooltip="Restore this issue"
-						color="accent"
-						(click)="admin.onRestore(issue, 'Issue', 'issues')">
-						<mat-icon aria-label="Remove this issue">restore</mat-icon>
-					</button>
-					<button mat-icon-button
-						*ngIf="!issue.softDeleted"
-						matTooltip="Remove this Issue"
-						color="accent"
-						(click)="admin.onSoftDelete(issue, 'Issue', 'issues')">
-						<mat-icon aria-label="Remove this issue">delete</mat-icon>
-					</button>
-					<button 
-						*ngIf="auth.isAdmin()"
-						mat-icon-button
-						matTooltip="Delete this Issue"
-						color="warn"
-						(click)="admin.onDelete(issue, 'Issue', 'issues')">
-						<mat-icon aria-label="Delete the issue forever">delete_forever</mat-icon>
-					</button>
-				</div>
-			</div>
-			<div fxLayout="row"
-				fxFlex></div>
-			<!-- <div fxLayout="column"
+    <mat-toolbar [@fadeIn]="!isLoading"
+        color="primary"
+        class="header-info-panel"
+        *ngIf="issue">
+        <div class="image-container"
+            fxLayout="column"
+            [defaultImage]="handleImageUrl(issue.imageUrl, true)"
+            [lazyLoad]="handleImageUrl(issue.imageUrl)">
+            <div class="admin-panel"
+                *ngIf="auth.isModerator(issue)"
+                fxLayout="column"
+                fxLayoutAlign="center end">
+                <div class="button-panel">
+                    <button mat-icon-button
+                        matTooltip="Create a new Issue"
+                        color="accent"
+                        routerLink="/issues/create">
+                        <mat-icon aria-label="Create a new issue">add</mat-icon>
+                    </button>
+                    <button mat-icon-button
+                        matTooltip="Add Solution for this Issue"
+                        color="accent"
+                        routerLink="/solutions/create/{{issue._id}}">
+                        <mat-icon aria-label="Add a new solution">playlist_add
+                        </mat-icon>
+                    </button>
+                    <button mat-icon-button
+                        matTooltip="Add Media to this Issue"
+                        color="accent"
+                        routerLink="/media/create/{{issue._id}}">
+                        <mat-icon aria-label="Add new media">add_a_photo
+                        </mat-icon>
+                    </button>
+                    <button mat-icon-button
+                        matTooltip="Edit this Issue"
+                        color="accent"
+                        routerLink="/issues/edit/{{issue._id}}">
+                        <mat-icon aria-label="Edit the issue">edit</mat-icon>
+                    </button>
+                    <button mat-icon-button
+                        *ngIf="issue.softDeleted"
+                        matTooltip="Restore this issue"
+                        color="accent"
+                        (click)="admin.onRestore(issue, 'Issue', 'issues')">
+                        <mat-icon aria-label="Remove this issue">restore
+                        </mat-icon>
+                    </button>
+                    <button mat-icon-button
+                        *ngIf="!issue.softDeleted"
+                        matTooltip="Remove this Issue"
+                        color="accent"
+                        (click)="admin.onSoftDelete(issue, 'Issue', 'issues')">
+                        <mat-icon aria-label="Remove this issue">delete
+                        </mat-icon>
+                    </button>
+                    <button *ngIf="auth.isAdmin()"
+                        mat-icon-button
+                        matTooltip="Delete this Issue"
+                        color="warn"
+                        (click)="admin.onDelete(issue, 'Issue', 'issues')">
+                        <mat-icon aria-label="Delete the issue forever">
+                            delete_forever</mat-icon>
+                    </button>
+                </div>
+            </div>
+            <div fxLayout="row"
+                fxFlex></div>
+            <!-- <div fxLayout="column"
 				fxLayoutAlign="start start">
 			</div> -->
-			<div fxLayout="row wrap"
-				fxLayoutAlign="center center">
-				<div fxFlex.gt-sm="690px"
-					fxFlex.gt-md="800px">
-					<app-share-buttons></app-share-buttons>
-				</div>
-			</div>
-		</div>
-		<div fxLayout="row wrap"
-			fxLayoutAlign="center center"
-			class="description-container">
-			<div fxFlex.gt-sm="690px"
-				fxFlex.gt-md="800px">
-				<div class="mat-display-1"
-					translate>{{issue.name}}</div>
-				<app-topic-tags [topics]="issue.topics"></app-topic-tags>
-				<app-more-less [displayText]="issue.description"
-					maxHeight="200">
-				</app-more-less>
-				<div *ngIf="auth.isVerified()">
-					<h4 class="mat-subheading-1">Do you have a suggestion that's not shown below? Click here to create one.</h4>
-					<button  mat-flat-button color="warn" (click)="populateSuggestion()">Make Suggestion</button>
-				</div>
-			</div>
-			
-			
-		</div>
-	</mat-toolbar>
+            <div fxLayout="row wrap"
+                fxLayoutAlign="center center">
+                <div fxFlex.gt-sm="690px"
+                    fxFlex.gt-md="800px">
+                    <app-share-buttons></app-share-buttons>
+                </div>
+            </div>
+        </div>
+        <div fxLayout="row wrap"
+            fxLayoutAlign="center center"
+            class="description-container">
+            <div fxFlex.gt-sm="690px"
+                fxFlex.gt-md="800px">
+                <div class="mat-display-1"
+                    translate>{{issue.name}}</div>
+                <app-topic-tags [topics]="issue.topics"></app-topic-tags>
+                <app-more-less [displayText]="issue.description"
+                    maxHeight="200">
+                </app-more-less>
+                <div *ngIf="auth.isVerified()">
+                    <h4 class="mat-subheading-1">Do you have a suggestion that's
+                        not shown below? Click here to create one.</h4>
+                    <button mat-flat-button
+                        color="warn"
+                        (click)="populateSuggestion()">Make Suggestion</button>
+                </div>
+            </div>
+        </div>
+    </mat-toolbar>
 </ng-template>
 
 
 <!-- Main Section -->
 
 <ng-template #skeletonCards>
-	<div class="container"
-		fxLayout="column"
-		fxLayoutAlign="center start"
-		>
-		<div class="skeleton-card-list"
-			>
-			<app-skeleton-text-bar [isSubtitle]=true [width]="150">
-			</app-skeleton-text-bar>
+    <div class="container"
+        fxLayout="column"
+        fxLayoutAlign="center start">
+        <div class="skeleton-card-list">
+            <app-skeleton-text-bar [isSubtitle]=true
+                [width]="150">
+            </app-skeleton-text-bar>
 
-			<app-skeleton-wide-card
-				[showImage]=true
-				[showContent]=true
-				[showActions]=true
-				[showChildren]=true
-			>
-			</app-skeleton-wide-card>
-			<app-skeleton-wide-card
-				[showImage]=true
-				[showContent]=true
-				[showActions]=true
-			>
-			</app-skeleton-wide-card>
-			<app-skeleton-wide-card
-				[showImage]=true
-				[showContent]=true
-				[showActions]=true
-			>
-			</app-skeleton-wide-card>
-		</div>	
-	</div>
-</ng-template> 
+            <app-skeleton-wide-card [showImage]=true
+                [showContent]=true
+                [showActions]=true
+                [showChildren]=true>
+            </app-skeleton-wide-card>
+            <app-skeleton-wide-card [showImage]=true
+                [showContent]=true
+                [showActions]=true>
+            </app-skeleton-wide-card>
+            <app-skeleton-wide-card [showImage]=true
+                [showContent]=true
+                [showActions]=true>
+            </app-skeleton-wide-card>
+        </div>
+    </div>
+</ng-template>
 
 <ng-template #mainCards>
-	<div class="container"
-		[@fadeIn]=true
-		fxLayout="row wrap"
-		fxLayoutAlign="center start">
-		<div fxFlex.gt-sm="690px"
-			fxFlex.gt-md="800px">
-			<mat-toolbar color="primary" fxLayoutAlign="center center" [style.margin-bottom]="'1rem'">
-				<span class="mat-headline center-span" [style.margin-bottom]="'0'">Vote on Solutions</span>
-			</mat-toolbar>
-			<app-card-list path="/solutions"
-				[items$]=solutions$
-				model="Solution"
-				[showChildren]="true"
-				childPath="proposals"
-				childName="Actions"
-				[showParent]="true"
-				parentPath="/issues"
-				parentPropName="issues"
-				(restore)="admin.onRestore($event, 'Solution')"
-				(delete)="admin.onDelete($event, 'Solution')"
-				(softDelete)="admin.onSoftDelete($event, 'Solution')"
-				(vote)="onVote($event, 'Solution')"
-				(childVote)="onVote($event, 'Proposal')">
-			</app-card-list>
-			<div>
-				<mat-toolbar color="primary" fxLayoutAlign="center center" [style.margin-bottom]="'1rem'">
-					<h2 class="mat-headline center-text">Community Suggestions</h2>
-				</mat-toolbar>
-				<app-card-list 
-					path="/suggestions"
-					[@fadeIn]=true
-					[items$]=suggestions$
-					model="Suggestion"
-					(restore)="admin.onRestore($event, 'Suggestion')"
-					(softDelete)="admin.onSoftDelete($event, 'Suggestion')"
-					(delete)="admin.onDelete($event, 'Suggestion')"
-					(vote)="onVote($event, 'Suggestion')"
-					>
-				</app-card-list>
-			</div>
-			<div *ngIf="auth.isVerified()">
-				<mat-toolbar color="primary" fxLayoutAlign="center center" [style.margin-bottom]="'1rem'">
-					<h2 class="mat-headline center-text">Create your own Suggestion</h2>
-				</mat-toolbar>
-				<app-make-suggestion
-					parent="solution"
-					(submitForm)="handleSuggestionSubmit($event)"
-					>
-				</app-make-suggestion>
-			</div>
-		</div>
-	</div>
+    <div class="container"
+        [@fadeIn]=true
+        fxLayout="row wrap"
+        fxLayoutAlign="center start">
+        <div fxFlex.gt-sm="690px"
+            fxFlex.gt-md="800px">
+            <mat-toolbar color="primary"
+                fxLayoutAlign="center center"
+                [style.margin-bottom]="'1rem'">
+                <span class="mat-headline center-span"
+                    [style.margin-bottom]="'0'">Vote on Solutions</span>
+            </mat-toolbar>
+            <app-card-list path="/solutions"
+                [items$]=solutions$
+                model="Solution"
+                [showChildren]="true"
+                childPath="proposals"
+                childName="Actions"
+                [showParent]="true"
+                parentPath="/issues"
+                parentPropName="issues"
+                (restore)="admin.onRestore($event, 'Solution')"
+                (delete)="admin.onDelete($event, 'Solution')"
+                (softDelete)="admin.onSoftDelete($event, 'Solution')"
+                (vote)="onVote($event, 'Solution')"
+                (childVote)="onVote($event, 'Proposal')">
+            </app-card-list>
+            <div>
+                <mat-toolbar color="primary"
+                    fxLayoutAlign="center center"
+                    [style.margin-bottom]="'1rem'">
+                    <h2 class="mat-headline center-text">Community Suggestions
+                    </h2>
+                </mat-toolbar>
+                <app-card-list path="/suggestions"
+                    [@fadeIn]=true
+                    [items$]=suggestions$
+                    model="Suggestion"
+                    (restore)="admin.onRestore($event, 'Suggestion')"
+                    (softDelete)="admin.onSoftDelete($event, 'Suggestion')"
+                    (delete)="admin.onDelete($event, 'Suggestion')"
+                    (vote)="onVote($event, 'Suggestion')">
+                </app-card-list>
+            </div>
+            <div *ngIf="auth.isVerified()">
+                <mat-toolbar color="primary"
+                    fxLayoutAlign="center center"
+                    [style.margin-bottom]="'1rem'">
+                    <h2 class="mat-headline center-text">Create your own
+                        Suggestion</h2>
+                </mat-toolbar>
+                <app-make-suggestion parent="solution"
+                    (submitForm)="handleSuggestionSubmit($event)">
+                </app-make-suggestion>
+            </div>
+        </div>
+    </div>
 
 </ng-template>

--- a/src/app/issue/view/issue-view.component.ts
+++ b/src/app/issue/view/issue-view.component.ts
@@ -125,8 +125,8 @@ export class IssueViewComponent implements OnInit {
 				(err) => console.log(err))
 	}
 
-	subscribeToSolutionStore(id: string) {
-		this.solutions$ = this.solutionQuery.selectSolutions()
+	subscribeToSolutionStore(issueId: string) {
+		this.solutions$ = this.solutionQuery.selectSolutions(issueId)
 	}
 
 	subscribeToMediaStore(id: string) {
@@ -170,7 +170,8 @@ export class IssueViewComponent implements OnInit {
 							image: issue.imageUrl || ''
 						});
 					this.stateService.setLoadingState(AppState.complete);
-				}
+				},
+				(err) => err
 			)
 	}
 
@@ -256,6 +257,7 @@ export class IssueViewComponent implements OnInit {
 	}
 
 	handleSubmit(value?: string) {
+
 		this.toggleHeader();
 		if (!value) {
 			return;

--- a/src/app/issue/view/issue-view.component.ts
+++ b/src/app/issue/view/issue-view.component.ts
@@ -104,6 +104,7 @@ export class IssueViewComponent implements OnInit {
 			this.subscribeToMediaStore(ID);
 			this.fetchData(ID);
 			this.getMedia(ID);
+			this.getTopics();
 		});
 
 		this.getSuggestions();
@@ -117,16 +118,18 @@ export class IssueViewComponent implements OnInit {
 
 
 	subscribeToIssueStore(id: string) {
-		this.issueQuery.selectEntity(id)
+		this.issueQuery.getIssueWithTopic(id)
 			.subscribe(
 				(issue: Issue) => {
+					if (!issue) return issue;
 					this.issue = issue;
+					this.stateService.setLoadingState(AppState.complete);
 				},
 				(err) => console.log(err))
 	}
 
 	subscribeToSolutionStore(issueId: string) {
-		this.solutions$ = this.solutionQuery.selectSolutions(issueId)
+		this.solutions$ = this.solutionQuery.selectSolutions(issueId);
 	}
 
 	subscribeToMediaStore(id: string) {
@@ -141,6 +144,20 @@ export class IssueViewComponent implements OnInit {
 		this.getProposals();
 		this.getSolutions();
 		this.getSuggestions();
+		this.getTopics();
+	}
+
+	getTopics() {
+		const isOwner = this.auth.isOwner();
+		const params = {
+			'showDeleted': isOwner ? true : ''
+		}
+
+		this.topicService.list({ orgs: [], params })
+			.subscribe(
+				res => res,
+				err => err
+			);
 	}
 
 	getSuggestions() {
@@ -169,7 +186,6 @@ export class IssueViewComponent implements OnInit {
 							description: issue.description || '',
 							image: issue.imageUrl || ''
 						});
-					this.stateService.setLoadingState(AppState.complete);
 				},
 				(err) => err
 			)

--- a/src/app/proposal/view/proposal-view.component.ts
+++ b/src/app/proposal/view/proposal-view.component.ts
@@ -95,7 +95,9 @@ export class ProposalViewComponent implements OnInit {
 	subscribeToProposalStore(id: string) {
 		this.proposalQuery.selectEntity(id)
 			.subscribe((proposal: Proposal) => {
+				if (!proposal) return false;
 				this.proposal = proposal;
+				return this.stateService.setLoadingState(AppState.complete);
 			})
 	}
 
@@ -125,7 +127,6 @@ export class ProposalViewComponent implements OnInit {
 							description: proposal.description,
 							image: proposal.imageUrl
 						});
-					return this.stateService.setLoadingState(AppState.complete);
 				},
 				(error) => {
 					return this.stateService.setLoadingState(AppState.serverError);
@@ -158,65 +159,6 @@ export class ProposalViewComponent implements OnInit {
 					}
 				}
 			);
-	}
-
-	onDelete() {
-		const dialogRef: MatDialogRef<ConfirmDialogComponent> = this.dialog.open(ConfirmDialogComponent, {
-			width: '250px',
-			data: {
-				title: `Delete Proposal?`,
-				message: `Are you sure you want to delete ${this.proposal.title}? This action cannot be undone.`
-			}
-		});
-
-		dialogRef.afterClosed().subscribe((confirm: boolean) => {
-			if (confirm) {
-				this.proposalService.delete({ id: this.proposal._id }).subscribe(() => {
-					this.openSnackBar('Succesfully deleted', 'OK');
-					this.router.navigate(['/proposals'], { queryParams: { forceUpdate: true } });
-				});
-			}
-		});
-	}
-
-	onSoftDelete() {
-		const dialogRef: MatDialogRef<ConfirmDialogComponent> = this.dialog.open(ConfirmDialogComponent, {
-			width: '250px',
-			data: {
-				title: `Remove Proposal?`,
-				message: `Are you sure you want to remove ${this.proposal.title}? This will only hide the item from the public.`
-			}
-		});
-
-		dialogRef.afterClosed().subscribe((confirm: boolean) => {
-			if (confirm) {
-				const entity = assign({}, this.proposal, { softDeleted: true });
-				this.proposalService.update({ id: this.proposal._id, entity }).subscribe(() => {
-					this.openSnackBar('Succesfully removed', 'OK');
-					this.router.navigate(['/solutions'], { queryParams: { forceUpdate: true } });
-				});
-			}
-		});
-	}
-
-	onRestore() {
-		const dialogRef: MatDialogRef<ConfirmDialogComponent> = this.dialog.open(ConfirmDialogComponent, {
-			width: '250px',
-			data: {
-				title: `Restore Proposal?`,
-				message: `Are you sure you want to restore ${this.proposal.title}? This will make the item visible to the public.`
-			}
-		});
-
-		dialogRef.afterClosed().subscribe((confirm: boolean) => {
-			if (confirm) {
-				const entity = assign({}, this.proposal, { softDeleted: false });
-				this.proposalService.update({ id: this.proposal._id, entity }).subscribe(() => {
-					this.openSnackBar('Succesfully restored', 'OK');
-					this.router.navigate(['/solutions'], { queryParams: { forceUpdate: true } });
-				});
-			}
-		});
 	}
 
 	openSnackBar(message: string, action: string) {

--- a/src/app/shared/vote-buttons/vote-buttons.component.html
+++ b/src/app/shared/vote-buttons/vote-buttons.component.html
@@ -36,7 +36,7 @@
         <h6 class="mat-body-2"
             [style.margin]="0">RESULTS <span *ngIf="userHasVoted()"
                 class="mat-body-2">
-                {{ storeVote && storeVote.total || item.votes.total }}</span>
+                {{ item.votes.total || storeVote && storeVote.total }}</span>
         </h6>
         <div *ngIf="userHasVoted(); else elseBlock"
             class="chart-container">

--- a/src/app/shared/vote-buttons/vote-buttons.component.html
+++ b/src/app/shared/vote-buttons/vote-buttons.component.html
@@ -36,7 +36,7 @@
         <h6 class="mat-body-2"
             [style.margin]="0">RESULTS <span *ngIf="userHasVoted()"
                 class="mat-body-2">
-                {{ item.votes.total || storeVote && storeVote.total }}</span>
+                {{ storeVote.total || item.votes.total }}</span>
         </h6>
         <div *ngIf="userHasVoted(); else elseBlock"
             class="chart-container">

--- a/src/app/shared/vote-buttons/vote-buttons.component.ts
+++ b/src/app/shared/vote-buttons/vote-buttons.component.ts
@@ -74,21 +74,21 @@ export class VoteButtonsComponent implements OnInit {
 	}
 
 	upVotesAsPercent() {
-		return this.getPercentage(this.item) || 0;
+		return this.getPercentage(this.storeVote || this.item) || 0;
 	}
 
 	downVotesAsPercent() {
-		return 100 - this.getPercentage(this.item) || 0;
+		return 100 - this.getPercentage(this.storeVote || this.item.votes) || 0;
 	}
 
 	getPercentage(item: any) {
-		if (item.votes.total === 0) {
+		if (item.total === 0) {
 			// no votes yet
 			return 0;
 		}
 
-		const numerator = item.votes.up;
-		const denominator = (item.votes.up + item.votes.down);
+		const numerator = item.up;
+		const denominator = (item.up + item.down);
 
 		if (denominator === 0) {
 			// stop divide by zero

--- a/src/app/solution/view/solution-view.component.ts
+++ b/src/app/solution/view/solution-view.component.ts
@@ -108,8 +108,6 @@ export class SolutionViewComponent implements OnInit {
 							description: solution.description,
 							image: solution.imageUrl
 						});
-
-					return this.stateService.setLoadingState(AppState.complete);
 				},
 				(err) => this.stateService.setLoadingState(AppState.serverError)
 			);
@@ -140,7 +138,11 @@ export class SolutionViewComponent implements OnInit {
 
 	subscribeToSolutionStore(id: string) {
 		this.solutionQuery.selectEntity(id)
-			.subscribe((solution: Solution) => this.solution = solution)
+			.subscribe((solution: Solution) => {
+				if (!solution) return false;
+				this.solution = solution;
+				this.stateService.setLoadingState(AppState.complete);
+			})
 	}
 
 	subscribeToSuggestionStore(id: string) {

--- a/src/app/suggestion/view/suggestion-view.component.ts
+++ b/src/app/suggestion/view/suggestion-view.component.ts
@@ -68,7 +68,9 @@ export class SuggestionViewComponent implements OnInit {
 	subscribeToSuggestionStore(id: string) {
 		this.suggestionQuery.selectEntity(id)
 			.subscribe((suggestion: Suggestion) => {
+				if (!suggestion) return false;
 				this.suggestion = suggestion;
+				this.stateService.setLoadingState(AppState.complete);
 			})
 	}
 
@@ -82,7 +84,6 @@ export class SuggestionViewComponent implements OnInit {
 							appBarTitle: 'View Suggestion',
 							description: suggestion.description
 						});
-					return this.stateService.setLoadingState(AppState.complete);
 				},
 				(err) => this.stateService.setLoadingState(AppState.serverError)
 			);

--- a/src/app/topic/view/topic-view.component.html
+++ b/src/app/topic/view/topic-view.component.html
@@ -4,68 +4,71 @@
 <mat-toolbar color="primary"
     class="header-info-panel"
     *ngIf="topic">
-	<div class="image-container"
-		fxLayout="column"
-		[defaultImage]="handleImageUrl(topic.imageUrl, true)"
-		[lazyLoad]="handleImageUrl(topic.imageUrl)">
-		<div class="admin-panel"
-		    *ngIf="auth.isModerator(topic)"
-		    fxLayout="column"
-		    fxLayoutAlign="center end">
-			<div class="button-panel">
-				<button mat-icon-button
-				    matTooltip="Add a new Issue"
-				    color="accent"
-				    routerLink="/issues/create">
-    					<mat-icon aria-label="Add a new issue">playlist_add</mat-icon>
-  					</button>
-				<button mat-icon-button
-				    matTooltip="Edit this Topic"
-				    color="accent"
-				    routerLink="/topics/edit/{{topic._id}}">
-    					<mat-icon aria-label="Edit the topic">edit</mat-icon>
-  					</button>
-				<button mat-icon-button
-				    matTooltip="Delete this Topic"
-				    color="warn"
-				    (click)="onDelete()">
-    					<mat-icon aria-label="Delete the topic forever">delete_forever</mat-icon>
-  					</button>
-			</div>
-		</div>
-		<div fxLayout="row" fxFlex></div>
-		<!-- <div fxLayout="column"
+    <div class="image-container"
+        fxLayout="column"
+        [defaultImage]="handleImageUrl(topic.imageUrl, true)"
+        [lazyLoad]="handleImageUrl(topic.imageUrl)">
+        <div class="admin-panel"
+            *ngIf="auth.isModerator(topic)"
+            fxLayout="column"
+            fxLayoutAlign="center end">
+            <div class="button-panel">
+                <button mat-icon-button
+                    matTooltip="Add a new Issue"
+                    color="accent"
+                    routerLink="/issues/create">
+                    <mat-icon aria-label="Add a new issue">playlist_add
+                    </mat-icon>
+                </button>
+                <button mat-icon-button
+                    matTooltip="Edit this Topic"
+                    color="accent"
+                    routerLink="/topics/edit/{{topic._id}}">
+                    <mat-icon aria-label="Edit the topic">edit</mat-icon>
+                </button>
+                <button mat-icon-button
+                    matTooltip="Delete this Topic"
+                    color="warn"
+                    (click)="admin.onDelete(topic, 'Topic', '/topics')">
+                    <mat-icon aria-label="Delete the topic forever">
+                        delete_forever</mat-icon>
+                </button>
+            </div>
+        </div>
+        <div fxLayout="row"
+            fxFlex></div>
+        <!-- <div fxLayout="column"
 		    fxLayoutAlign="start start">
 		</div> -->
-		<div fxLayout="row wrap"
-			fxLayoutAlign="center center">
-			<div fxFlex.gt-sm="690px"
-				fxFlex.gt-md="800px">
-				<app-share-buttons></app-share-buttons>
-			</div>
-		</div>
-	</div>
-	<div fxLayout="row wrap"
-	    fxLayoutAlign="center center">
-		<div fxFlex.gt-sm="690px"
-		    fxFlex.gt-md="800px">
-			<div class="mat-display-1"
-			    translate>{{topic.name}}</div>
-			<app-more-less [displayText]="topic.description"
-			    maxHeight="200">
-			</app-more-less>
-		</div>
-	</div>
+        <div fxLayout="row wrap"
+            fxLayoutAlign="center center">
+            <div fxFlex.gt-sm="690px"
+                fxFlex.gt-md="800px">
+                <app-share-buttons></app-share-buttons>
+            </div>
+        </div>
+    </div>
+    <div fxLayout="row wrap"
+        fxLayoutAlign="center center">
+        <div fxFlex.gt-sm="690px"
+            fxFlex.gt-md="800px">
+            <div class="mat-display-1"
+                translate>{{topic.name}}</div>
+            <app-more-less [displayText]="topic.description"
+                maxHeight="200">
+            </app-more-less>
+        </div>
+    </div>
 </mat-toolbar>
 
 <div class="container"
     fxLayout="row wrap"
     fxLayoutAlign="center start">
-	<div fxFlex.gt-sm="690px"
-	    fxFlex.gt-md="800px">
-		<app-grid-list *ngIf="topic"
-		    path="/issues"
-		    model="Issue"
-		    [items]=issues></app-grid-list>
-	</div>
+    <div fxFlex.gt-sm="690px"
+        fxFlex.gt-md="800px">
+        <app-grid-list *ngIf="topic"
+            path="/issues"
+            model="Issue"
+            [items]=issues></app-grid-list>
+    </div>
 </div>

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -5,6 +5,7 @@ export const environment = {
 	production: true,
 	version: env.npm_package_version,
 	serverUrl: 'https://api.newvote.org/api',
+	socketUrl: 'https://api.newvote.org/',
 	defaultLanguage: 'en-US',
 	supportedLanguages: [
 		'en-US',

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -6,7 +6,7 @@
 import env from './.env'
 
 export const environment = {
-    production: true,
+    production: false,
     version: env.npm_package_version + '-dev',
     serverUrl: 'https://api.staging.newvote.org/api',
     socketUrl: 'https://api.staging.newvote.org/',

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -9,6 +9,7 @@ export const environment = {
     production: true,
     version: env.npm_package_version + '-dev',
     serverUrl: 'https://api.staging.newvote.org/api',
+    socketUrl: 'https://api.staging.newvote.org/',
     defaultLanguage: 'en-US',
     supportedLanguages: [
         'en-US',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -9,6 +9,7 @@ export const environment = {
 	production: false,
 	version: env.npm_package_version + '-dev',
 	serverUrl: '/api',
+	socketUrl: '',
 	defaultLanguage: 'en-US',
 	supportedLanguages: [
 		'en-US',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -9,7 +9,7 @@ export const environment = {
 	production: false,
 	version: env.npm_package_version + '-dev',
 	serverUrl: '/api',
-	socketUrl: '',
+	socketUrl: 'http://localhost:3000',
 	defaultLanguage: 'en-US',
 	supportedLanguages: [
 		'en-US',


### PR DESCRIPTION
Required backend branch `feature/websockets` 

Opening the PR just to signal can be uploaded / deployed on the staging branch.

Akita docs: https://netbasal.gitbook.io/akita/

If you want to see the state update and track changes picking up `redux dev tools` plugin for chrome / firefox would help.
https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd

Main changes:
1) Most of the entity types have been moved to the akita store. If you check the `core/http` folder anything with a `query / store` file is hooked up to akita.
2) Gutted most components `onDelete / onRestore / onSoftDelete` and moved them all to a single service which will direct the commands to the right services. The main entity components `proposal/solution/issue` etc now call the service via the template.
3) All store updates happen via the `http` services by tapping in to the observable data. With the exception of voting. Once the vote has been updated and returned to the component we make an extra call to update the entity with the latest data.
4) Shared components `card-list / grid-list` are now passed an observable and are resolved on the template via `items$` var. There's also a `trackBy` function - https://netbasal.com/angular-2-improve-performance-with-trackby-cc147b5104e5

When using it, it stops the components flashing when they update.

5) App flow has slightly changed, so when a user opens a new page we still make an api call via `view / list` on the service when the component loads. When the data is returned we `tap` into it and send that data to the store. But we still resolve the observable on the component we don't do anything with it. Instead we fetch the data via the `query` component which gets it's data from the store.
6) On a couple of pages i.e `solutions` on the `issues/view` or `solutions/list` page  we have custom queries which map `proposals` from the proposals store to solutions but for the most part we use the standard api methods that akita comes with. 

Couple of issues ran into, occasionally elements removed from the store don't always disappear when switching between pages. I haven't been able to reproduce, might be to do with caching. Akita has it's own caching methods as well but i believe they are turned off normally.

The skeleton components aren't working quite as well as they were before. Akita has it's on internal loading state + error states that could look at but haven't had the opportunity yet.