### PR TITLE
Moderator fail feedback

### DIFF
--- a/src/app/core/http/organization/organization.service.ts
+++ b/src/app/core/http/organization/organization.service.ts
@@ -111,7 +111,7 @@ export class OrganizationService {
         return this.httpClient
             .post(routes.create(), context.entity)
             .pipe(
-                tap((res: Organization) => this.communityStore.add(res)),
+                tap((res: any) => this.communityStore.add(res.organization)),
                 map((res: any) => res),
                 catchError(handleError)
             )

--- a/src/app/core/http/organization/organization.service.ts
+++ b/src/app/core/http/organization/organization.service.ts
@@ -118,16 +118,25 @@ export class OrganizationService {
     }
 
     update(context: OrganizationContext): Observable<any> {
+        // Organization update returns an object
+        /*
+             moderators array - a collection of moderators that was not saved
+             {
+                 organization: object
+                 moderators: array
+             }
+        */
+
         return this.httpClient
             .put(routes.update(context), context.entity)
             .pipe(
-                tap((res: Organization) => {
+                tap((res: any) => {
                     // since there are two stores we need to check whether to update both
                     if (res._id === this._org._id) {
-                        this.organizationStore.update(res)
+                        this.organizationStore.update(res.organization)
                     }
 
-                    this.communityStore.update(res._id, res)
+                    this.communityStore.update(res._id, res.organization)
                 }),
                 map((res: any) => res),
                 catchError(handleError)

--- a/src/app/organization/create/organization-create.component.scss
+++ b/src/app/organization/create/organization-create.component.scss
@@ -1,40 +1,45 @@
 .container {
-	text-align: center;
-	padding: 1em;
+    text-align: center;
+    padding: 1em;
 }
 
 .image-select {
-	margin-bottom: 25px;
+    margin-bottom: 25px;
 
-	.image-preview {
-		width: 100%;
-		max-height: 250px;
+    .image-preview {
+        width: 100%;
+        max-height: 250px;
 
-		img {
-			max-width: 100%;
-			max-height: 250px;
-			height: auto;
-		}
-	}
+        img {
+            max-width: 100%;
+            max-height: 250px;
+            height: auto;
+        }
+    }
 }
 
 .quill-editor-container {
-	margin-top: 25px;
-	margin-bottom: 25px;
+    margin-top: 25px;
+    margin-bottom: 25px;
 }
 
 ::ng-deep {
-	.ql-container {
-		height: 250px !important;
-	}
+    .ql-container {
+        height: 250px !important;
+    }
 }
 
 .vote-container {
-	padding-left: 1rem;
-	margin-bottom: 0.25rem;
-	margin-top: 1rem;
+    padding-left: 1rem;
+    margin-bottom: 0.25rem;
+    margin-top: 1rem;
 }
 
 .vote-section {
-	margin-bottom: 1rem;
+    margin-bottom: 1rem;
+}
+
+.warn-snack {
+    color: #ffca28;
+    border: 1px solid #ffca28
 }

--- a/src/app/organization/create/organization-create.component.ts
+++ b/src/app/organization/create/organization-create.component.ts
@@ -1,6 +1,6 @@
 import { COMMA, ENTER, SPACE } from '@angular/cdk/keycodes'
 import { Component, OnInit, ElementRef, ViewChild } from '@angular/core'
-import { MatAutocomplete, MatSnackBar } from '@angular/material'
+import { MatAutocomplete, MatSnackBar, MatSnackBarConfig } from '@angular/material'
 import { Router, ActivatedRoute } from '@angular/router'
 import { FormGroup, FormControl, Validators, FormArray } from '@angular/forms'
 import { FileUploader, FileUploaderOptions } from 'ng2-file-upload'
@@ -202,8 +202,12 @@ export class OrganizationCreateComponent implements OnInit {
                     this.openSnackBar('Succesfully created', 'OK')
 
                     if (res.moderators.length) {
+                        const config = new MatSnackBarConfig()
+                        config.duration = 2000
+                        config.panelClass = ['warn-snack']
+
                         setTimeout(() => {
-                            this.openSnackBar(`The following moderators failed to save: ${res.moderators.join(' ')}`, 'Error')
+                            this.openSnackBar(`The following moderators failed to save: ${res.moderators.join(' ')}`, 'Error', config)
                         }, 3100)
                     }
 
@@ -232,11 +236,13 @@ export class OrganizationCreateComponent implements OnInit {
         this.uploader.uploadAll()
     }
 
-    openSnackBar(message: string, action: string) {
-        this.snackBar.open(message, action, {
+    openSnackBar(message: string, action: string, config?: any) {
+        const defaultConfig = {
             duration: 3000,
             horizontalPosition: 'right'
-        })
+        }
+
+        this.snackBar.open(message, action, config || defaultConfig)
     }
 
     userSelected(event: any) {

--- a/src/app/organization/create/organization-create.component.ts
+++ b/src/app/organization/create/organization-create.component.ts
@@ -202,7 +202,9 @@ export class OrganizationCreateComponent implements OnInit {
                     this.openSnackBar('Succesfully created', 'OK')
 
                     if (res.moderators.length) {
-                        this.openSnackBar(`The following moderators failed to save: ${res.moderators.join(' ')}`, 'Error')
+                        setTimeout(() => {
+                            this.openSnackBar(`The following moderators failed to save: ${res.moderators.join(' ')}`, 'Error')
+                        }, 3100)
                     }
 
                     this.router.navigate(['/organizations'])
@@ -232,7 +234,7 @@ export class OrganizationCreateComponent implements OnInit {
 
     openSnackBar(message: string, action: string) {
         this.snackBar.open(message, action, {
-            duration: 4000,
+            duration: 3000,
             horizontalPosition: 'right'
         })
     }

--- a/src/app/organization/create/organization-create.component.ts
+++ b/src/app/organization/create/organization-create.component.ts
@@ -198,13 +198,17 @@ export class OrganizationCreateComponent implements OnInit {
         this.uploader.onCompleteAll = () => {
             this.organizationService.create({ entity: this.organization })
                 .pipe(finalize(() => { this.isLoading = false }))
-                .subscribe(t => {
-                    if (t.error) {
-                        this.openSnackBar(`Something went wrong: ${t.error.status} - ${t.error.statusText}`, 'OK')
-                    } else {
-                        this.openSnackBar('Succesfully created', 'OK')
-                        this.router.navigate(['/organizations'])
+                .subscribe(res => {
+                    this.openSnackBar('Succesfully created', 'OK')
+
+                    if (res.moderators.length) {
+                        this.openSnackBar(`The following moderators failed to save: ${res.moderators.join(' ')}`, 'Error')
                     }
+
+                    this.router.navigate(['/organizations'])
+                },
+                (error) => {
+                    this.openSnackBar(`Something went wrong: ${error.status} - ${error.statusText}`, 'OK')
                 })
         }
 
@@ -241,7 +245,7 @@ export class OrganizationCreateComponent implements OnInit {
         this.userInput.nativeElement.value = ''
     }
 
-    userRemoved() {
+    userRemoved(user: any) {
         this.owner = null
     }
 

--- a/src/app/organization/edit/organization-edit.component.scss
+++ b/src/app/organization/edit/organization-edit.component.scss
@@ -1,47 +1,52 @@
 .container {
-	text-align: center;
-	padding: 1em;
+    text-align: center;
+    padding: 1em;
 }
 
 .image-select {
-	margin-bottom: 25px;
+    margin-bottom: 25px;
 
-	.image-preview {
-		width: 100%;
-		max-height: 250px;
+    .image-preview {
+        width: 100%;
+        max-height: 250px;
 
-		img {
-			max-width: 100%;
-			max-height: 250px;
-			height: auto;
-		}
-	}
+        img {
+            max-width: 100%;
+            max-height: 250px;
+            height: auto;
+        }
+    }
 }
 
 
 .quill-editor-container {
-	margin-top: 25px;
-	margin-bottom: 25px;
+    margin-top: 25px;
+    margin-bottom: 25px;
 }
 
 ::ng-deep {
-	.ql-container {
-		height: 250px !important;
-	}
+    .ql-container {
+        height: 250px !important;
+    }
 }
 
 .future-chip {
-	font-size: 0.8em;
-	background-color: #0277bd;
-	color: white;
+    font-size: 0.8em;
+    background-color: #0277bd;
+    color: white;
 }
 
 .vote-container {
-	padding-left: 1rem;
-	margin-bottom: 0.25rem;
-	margin-top: 1rem;
+    padding-left: 1rem;
+    margin-bottom: 0.25rem;
+    margin-top: 1rem;
 }
 
 .vote-section {
-	margin-bottom: 1rem;
+    margin-bottom: 1rem;
+}
+
+.warn-snack {
+    color: #ffca28;
+    border: 1px solid #ffca28
 }

--- a/src/app/organization/edit/organization-edit.component.ts
+++ b/src/app/organization/edit/organization-edit.component.ts
@@ -312,7 +312,9 @@ export class OrganizationEditComponent implements OnInit {
                 this.openSnackBar('Succesfully updated', 'OK')
 
                 if (res.moderators.length) {
-                    this.openSnackBar(`The following moderators failed to save: ${res.moderators.join(' ')}`, 'Error')
+                    setTimeout(() => {
+                        this.openSnackBar(`The following moderators failed to save: ${res.moderators.join(' ')}`, 'Error')
+                    }, 3100)
                 }
 
                 this.location.back()
@@ -324,7 +326,7 @@ export class OrganizationEditComponent implements OnInit {
 
     openSnackBar(message: string, action: string) {
         this.snackBar.open(message, action, {
-            duration: 4000,
+            duration: 3000,
             horizontalPosition: 'center'
         })
     }

--- a/src/app/organization/edit/organization-edit.component.ts
+++ b/src/app/organization/edit/organization-edit.component.ts
@@ -308,8 +308,13 @@ export class OrganizationEditComponent implements OnInit {
 
         this.organizationService.update({ id: organization._id, entity: organization })
             .pipe(finalize(() => { this.isLoading = false }))
-            .subscribe(() => {
+            .subscribe((res) => {
                 this.openSnackBar('Succesfully updated', 'OK')
+
+                if (res.moderators.length) {
+                    this.openSnackBar(`The following moderators failed to save: ${res.moderators.join(' ')}`, 'Error')
+                }
+
                 this.location.back()
             },
             (error) => {

--- a/src/app/organization/edit/organization-edit.component.ts
+++ b/src/app/organization/edit/organization-edit.component.ts
@@ -313,7 +313,7 @@ export class OrganizationEditComponent implements OnInit {
 
                 if (res.moderators.length) {
                     const config = new MatSnackBarConfig()
-                    config.duration = 2000
+                    config.duration = 3000
                     config.panelClass = ['warn-snack']
 
                     setTimeout(() => {

--- a/src/app/organization/edit/organization-edit.component.ts
+++ b/src/app/organization/edit/organization-edit.component.ts
@@ -1,7 +1,7 @@
 import { COMMA, ENTER, SPACE } from '@angular/cdk/keycodes'
 import { Component, OnInit, ElementRef, ViewChild } from '@angular/core'
 import { Location } from '@angular/common'
-import { MatAutocomplete, MatSnackBar } from '@angular/material'
+import { MatAutocomplete, MatSnackBar, MatSnackBarConfig } from '@angular/material'
 import { ActivatedRoute } from '@angular/router'
 import { FormGroup, FormControl, Validators, FormArray } from '@angular/forms'
 import { FileUploader, FileUploaderOptions } from 'ng2-file-upload'
@@ -312,8 +312,12 @@ export class OrganizationEditComponent implements OnInit {
                 this.openSnackBar('Succesfully updated', 'OK')
 
                 if (res.moderators.length) {
+                    const config = new MatSnackBarConfig()
+                    config.duration = 2000
+                    config.panelClass = ['warn-snack']
+
                     setTimeout(() => {
-                        this.openSnackBar(`The following moderators failed to save: ${res.moderators.join(' ')}`, 'Error')
+                        this.openSnackBar(`The following moderators failed to save: ${res.moderators.join(' ')}`, 'Error', config)
                     }, 3100)
                 }
 
@@ -324,11 +328,13 @@ export class OrganizationEditComponent implements OnInit {
             })
     }
 
-    openSnackBar(message: string, action: string) {
-        this.snackBar.open(message, action, {
+    openSnackBar(message: string, action: string, config?: any) {
+        const defaultConfig = {
             duration: 3000,
-            horizontalPosition: 'center'
-        })
+            horizontalPosition: 'right'
+        }
+
+        this.snackBar.open(message, action, config || defaultConfig)
     }
 
     ownerSelected(event: any) {


### PR DESCRIPTION
Requires `feature/moderator-fail-feedback` on backend.

Updated the organization `create/edit` api response to send back an array of emails that failed to save from the server. 

The `edit/create` component now shows an extra toast showing all the emails.