### PR TITLE
Search results fix

### DIFF
--- a/src/app/core/http/search/search.service.ts
+++ b/src/app/core/http/search/search.service.ts
@@ -72,7 +72,9 @@ export class SearchService {
 
         return forkJoin([topicObs, issueObs, solutionObs, proposalObs]).pipe(
             map((resultsArray: Array<any>) => {
-                return [].concat([...resultsArray])
+                return resultsArray.reduce((prev, curr) => {
+                    return prev.concat(...curr)
+                }, [])
             })
         )
     }


### PR DESCRIPTION
The search service was returning a 2d array of objects and the template was returning a single array. Quick fix which flattens the 2d array so template can show a list of objects.